### PR TITLE
removed superfluous parts

### DIFF
--- a/src/pages/main_layout.cr
+++ b/src/pages/main_layout.cr
@@ -110,7 +110,7 @@ abstract class MainLayout
 
     ## What does Lucky look like?
     
-    Lucky can generate **action classes**, from class names that determine the default routing path(s).
+    Lucky can generate **action classes**, from class names that already determine usefull default routing path(s).
     The resulting classes map the routing path definition to a response block.
     
     Using classes allows to provide very [solid](https://thoughtbot.com/blog/designing-lucky-actions-routing) automatic

--- a/src/pages/main_layout.cr
+++ b/src/pages/main_layout.cr
@@ -110,8 +110,8 @@ abstract class MainLayout
 
     ## What does Lucky look like?
     
-    Lucky will generate **action classes** from class names that determine useful default routing path(s).
-    The resulting classes map the routing path definition to a response block.
+    Lucky will generate **action classes** from class names that describe the route and determine
+    the default routing path(s). The resulting classes map the routing path definition to a response block.
     
     Using separate classes allows to provide very [solid](https://thoughtbot.com/blog/designing-lucky-actions-routing) automatic
     error detection, as well as generation of routing, path, and link helpers and methods.

--- a/src/pages/main_layout.cr
+++ b/src/pages/main_layout.cr
@@ -110,11 +110,11 @@ abstract class MainLayout
 
     ## What does Lucky look like?
     
-    Lucky will generate **action classes**, from class names that already determine useful default routing path(s).
+    Lucky will generate **action classes** from class names that determine useful default routing path(s).
     The resulting classes map the routing path definition to a response block.
     
     Using separate classes allows to provide very [solid](https://thoughtbot.com/blog/designing-lucky-actions-routing) automatic
-    error detection, as well as generation of routing, path, and link methods and helpers.
+    error detection, as well as generation of routing, path, and link helpers and methods.
     
     ### JSON API
 

--- a/src/pages/main_layout.cr
+++ b/src/pages/main_layout.cr
@@ -110,11 +110,12 @@ abstract class MainLayout
 
     ## What does Lucky look like?
 
-    Lucky's code generator takes **class names** that describe a route, e.g. `Api::Users::Show`,
-    and creates the classes with corresponding routes. The classes map the routing path definition to a response block.
+    Lucky uses **action classes** for handling HTTP request routes and responses.
+    The classes map the routes and parameters it handles to a response block.
+    Lucky can generate these classes for you with 'lucky gen.action`.
 
-    Using a class per action (route+response) allows to provide very [solid](https://thoughtbot.com/blog/designing-lucky-actions-routing) automatic
-    error detection, as well as generation of routing, path, and link helpers and methods.
+    Using a class per action (route+response) allows to provide very [solid](https://thoughtbot.com/blog/designing-lucky-actions-routing)
+    automatic error detection, as well as generation of routing, path, and link helpers and methods.
 
     ### JSON API
 

--- a/src/pages/main_layout.cr
+++ b/src/pages/main_layout.cr
@@ -111,7 +111,7 @@ abstract class MainLayout
     ## What does Lucky look like?
     
     In Lucky we generate **action classes**, from class names that determine inferred default routing path(s).
-    The classes then map a routing path definition to a response block.
+    The resulting classes then map a routing path definition to a response block.
     
     Using classes allows to provide very [solid](https://thoughtbot.com/blog/designing-lucky-actions-routing) automatic
     error detection, as well as generation of routing, path, and link methods and helpers.

--- a/src/pages/main_layout.cr
+++ b/src/pages/main_layout.cr
@@ -110,8 +110,8 @@ abstract class MainLayout
 
     ## What does Lucky look like?
     
-    In Lucky we generate **action classes** with names that describe the route.
-    The classes then maps a routing path definition to a response block.
+    In Lucky we generate **action classes**, using names that determine inferred default routing path(s).
+    The classes then map a routing path definition to a response block.
     
     Using classes allows to provide very [solid](https://thoughtbot.com/blog/designing-lucky-actions-routing) automatic
     error detection, as well as generation of routing, path, and link methods and helpers.

--- a/src/pages/main_layout.cr
+++ b/src/pages/main_layout.cr
@@ -110,7 +110,7 @@ abstract class MainLayout
 
     ## What does Lucky look like?
     
-    In Lucky we generate **action classes**, using names that determine inferred default routing path(s).
+    In Lucky we generate **action classes**, from class names that determine inferred default routing path(s).
     The classes then map a routing path definition to a response block.
     
     Using classes allows to provide very [solid](https://thoughtbot.com/blog/designing-lucky-actions-routing) automatic

--- a/src/pages/main_layout.cr
+++ b/src/pages/main_layout.cr
@@ -110,7 +110,7 @@ abstract class MainLayout
 
     ## What does Lucky look like?
     
-    Lucky can generate **action classes**, from class names that already determine usefull default routing path(s).
+    Lucky can generate **action classes**, from class names that already determine useful default routing path(s).
     The resulting classes map the routing path definition to a response block.
     
     Using classes allows to provide very [solid](https://thoughtbot.com/blog/designing-lucky-actions-routing) automatic

--- a/src/pages/main_layout.cr
+++ b/src/pages/main_layout.cr
@@ -109,13 +109,13 @@ abstract class MainLayout
     If this sounds interesting, [let's get started](#{Guides::GettingStarted::Installing.path}).
 
     ## What does Lucky look like?
-    
-    Lucky will generate **action classes** from class names that describe the route and determine
-    the default routing path(s). The resulting classes map the routing path definition to a response block.
-    
-    Using separate classes allows to provide very [solid](https://thoughtbot.com/blog/designing-lucky-actions-routing) automatic
+
+    Lucky's code generator takes **class names** that describe a route, e.g. `Api::Users::Show`,
+    and creates the classes with corresponding routes. The classes map the routing path definition to a response block.
+
+    Using a class per action (route+response) allows to provide very [solid](https://thoughtbot.com/blog/designing-lucky-actions-routing) automatic
     error detection, as well as generation of routing, path, and link helpers and methods.
-    
+
     ### JSON API
 
     ```crystal

--- a/src/pages/main_layout.cr
+++ b/src/pages/main_layout.cr
@@ -110,8 +110,8 @@ abstract class MainLayout
 
     ## What does Lucky look like?
     
-    In Lucky we generate **action classes**, from class names that determine inferred default routing path(s).
-    The resulting classes then map a routing path definition to a response block.
+    Lucky can generate **action classes**, from class names that determine the default routing path(s).
+    The resulting classes map the routing path definition to a response block.
     
     Using classes allows to provide very [solid](https://thoughtbot.com/blog/designing-lucky-actions-routing) automatic
     error detection, as well as generation of routing, path, and link methods and helpers.

--- a/src/pages/main_layout.cr
+++ b/src/pages/main_layout.cr
@@ -110,8 +110,8 @@ abstract class MainLayout
 
     ## What does Lucky look like?
     
-    In Lucky we generate separate action classes with names that describe the route.
-    The resulting file maps routing path definitions to a response block.
+    In Lucky we generate **action classes** with names that describe the route.
+    The classes then maps a routing path definition to a response block.
     
     Using classes allows to provide very [solid](https://thoughtbot.com/blog/designing-lucky-actions-routing) automatic
     error detection, as well as generation of routing, path, and link methods and helpers.

--- a/src/pages/main_layout.cr
+++ b/src/pages/main_layout.cr
@@ -110,10 +110,10 @@ abstract class MainLayout
 
     ## What does Lucky look like?
     
-    Lucky can generate **action classes**, from class names that already determine useful default routing path(s).
+    Lucky will generate **action classes**, from class names that already determine useful default routing path(s).
     The resulting classes map the routing path definition to a response block.
     
-    Using classes allows to provide very [solid](https://thoughtbot.com/blog/designing-lucky-actions-routing) automatic
+    Using separate classes allows to provide very [solid](https://thoughtbot.com/blog/designing-lucky-actions-routing) automatic
     error detection, as well as generation of routing, path, and link methods and helpers.
     
     ### JSON API


### PR DESCRIPTION
Seeing it on the live site, the word "separate" seemed somehow superfluous, and consistently talking about classes better than mixing in files in the very beginning.