### PR TITLE
Fixed typos in database and http and routing guides

### DIFF
--- a/src/actions/guides/database/querying.cr
+++ b/src/actions/guides/database/querying.cr
@@ -355,7 +355,7 @@ class Guides::Database::Querying < GuideAction
     You can use this to help refine your association.
 
     ```crystal
-    UserQuery.new.join_taks.tasks { |task_query|
+    UserQuery.new.join_tasks.tasks { |task_query|
       # WHERE tasks.title = 'Clean up notes'
       task_query.title("Clean up notes")
     }

--- a/src/actions/guides/http_and_routing/routing_and_params.cr
+++ b/src/actions/guides/http_and_routing/routing_and_params.cr
@@ -16,13 +16,13 @@ class Guides::HttpAndRouting::RoutingAndParams < GuideAction
 
     ## Routing
 
-    Instead of having separate definition files for routes and cotrollers, Lucky combines them in action classes.
+    Instead of having separate definition files for routes and controllers, Lucky combines them in action classes.
     This allows for solid error detection, and method and helper creation.
 
     To save some typing, Lucky automatically infers a default route path from the name of the action class,
     if the name ends with a known [RESTful action (see below)](##{ANCHOR_AUTOMATICALLY_GENERATE_RESTFUL_ROUTES}).
     
-    For example, an action nemed `Item::Show` will by default respond to `get "/item/:item_id"`, a HTTP GET request
+    For example, an action named `Item::Show` will by default respond to `get "/item/:item_id"`, a HTTP GET request
     for a specific item, and have the requested item_id available as #{:item_id}.
 
     To see what a simple action looks like, let's generate an index action for showing users with


### PR DESCRIPTION
I found a couple of typos in the routing and params guide and made a quick fix. I also saw an open issue to fix a typo in the database querying guide, so I fixed that as well. 