### PR TITLE
Code should take less space when in text

### DIFF
--- a/src/css/components/_markdown-content.scss
+++ b/src/css/components/_markdown-content.scss
@@ -112,15 +112,14 @@
   }
 
   code:not(.hljs) {
-    @apply bg-blue-lightest;
     word-break: break-word;
     color: #16417c;
-    padding-left: 5px;
-    padding-right: 5px;
-    margin-left: 3px;
-    margin-right: 3px;
+    padding: 1px 4px 1px 4px;
+    margin-left: 1px;
+    margin-right: 1px;
     box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-    @apply border border-blue-lighter;
+    font-size: 15px;
+    @apply border border-blue-lighter bg-blue-lightest;
   }
 
   blockquote code:not(.hljs) {


### PR DESCRIPTION
The old styles made them too big so the code encroached on other lines.

This makes font and padding slightly smaller.

Old:
<img width="878" alt="Screen Shot 2019-09-19 at 4 43 42 PM" src="https://user-images.githubusercontent.com/22394/65279627-b84a4680-dafc-11e9-8939-36bc93bc9bfa.png">

New:
<img width="880" alt="Screen Shot 2019-09-19 at 4 45 24 PM" src="https://user-images.githubusercontent.com/22394/65279724-e4fe5e00-dafc-11e9-8f11-3b3de355389e.png">
