### PR TITLE
update routing and params example to user Auth:AllowGuests

### DIFF
--- a/src/actions/guides/http_and_routing/routing_and_params.cr
+++ b/src/actions/guides/http_and_routing/routing_and_params.cr
@@ -65,15 +65,19 @@ class Guides::HttpAndRouting::RoutingAndParams < GuideAction
     ```crystal
     # src/actions/home/index.cr
     class Home::Index < BrowserAction
-      include Auth::SkipRequireSignIn
+      include Auth::AllowGuests
 
       get "/" do
         if current_user?
-          # By default signed in users go to the profile page
-          # You can redirect them somewhere else if you prefer
           redirect Me::Show
         else
-          # Change this to redirect to a different page when not signed in
+          # When you're ready change this line to:
+          #
+          #   redirect SignIns::New
+          #
+          # Or maybe show signed out users a marketing page:
+          #
+          #   html Marketing::IndexPage
           html Lucky::WelcomePage
         end
       end


### PR DESCRIPTION
The example was still including the Auth::SkipRequireSignIn module that no longer exists. I replaced the example with the current exact code that is generated with lucky init, since it has improved comments as well.