### PR TITLE
Fix abstract method compilation warning in example

### DIFF
--- a/src/actions/guides/http_and_routing/security_headers.cr
+++ b/src/actions/guides/http_and_routing/security_headers.cr
@@ -25,13 +25,14 @@ class Guides::HttpAndRouting::SecurityHeaders < GuideAction
     abstract class BrowserAction < Lucky::Action
       include Lucky::SecureHeaders::SetFrameGuard
 
-      def frame_guard_value
+      def frame_guard_value : String
         "deny"
       end
     end
     ```
 
     > The `frame_guard_value` method is required, and must be `"sameorigin"`, `"deny"`, or a valid URL for your website.
+    > The explicit return type (`String` in this example) is required when you override abstract method with explicit return type.
 
     ### `SetSniffGuard`
 


### PR DESCRIPTION
Fixes #171

Starting with Crystal 0.30.0 the abstract methods return types are enforced.
https://github.com/crystal-lang/crystal/blob/master/CHANGELOG.md#language-changes-1

If you override an abstract method with explicit return type you must specify explicit return type in override as well. Otherwise you'll get a warning starting with Crystal 0.30.0 and an error in future versions.