### PR TITLE
Add missing semicolons.

### DIFF
--- a/src/actions/guides/deploying/ubuntu.cr
+++ b/src/actions/guides/deploying/ubuntu.cr
@@ -258,8 +258,8 @@ class Guides::Deploying::Ubuntu < GuideAction
                     proxy_pass http://lucky;
             }
 
-            ssl_certificate /etc/ssl/certs/ssl-cert-snakeoil.pem
-            ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key
+            ssl_certificate /etc/ssl/certs/ssl-cert-snakeoil.pem;
+            ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;
     }
     ```
 


### PR DESCRIPTION
I finally got around to testing my own instructions :grimacing: 

They worked quite well, but I still encountered a small error in the nginx configuration. Sorry for that.