### PR TITLE
Typo fix and release flag

### DIFF
--- a/src/actions/guides/database/models.cr
+++ b/src/actions/guides/database/models.cr
@@ -360,7 +360,7 @@ class Guides::Database::Models < GuideAction
 
     ```crystal
     photo = SavePhoto.create!
-    comment = SaveComment.create!(phot_id: photo.id)
+    comment = SaveComment.create!(photo_id: photo.id)
 
     comment.commentable == photo
     ```

--- a/src/actions/guides/getting-started/installing.cr
+++ b/src/actions/guides/getting-started/installing.cr
@@ -77,7 +77,7 @@ class Guides::GettingStarted::Installing < GuideAction
     * cd into the newly cloned directory
     * Check out latest [released version](https://github.com/luckyframework/lucky_cli/releases) `git checkout #{LuckyCliVersion.current_tag}`
     * Run `shards install`
-    * Run `crystal build src/lucky.cr`
+    * Run `crystal build --release src/lucky.cr`
     * Move the generated `lucky` binary to your path. Most of the time you can move
       it to `/usr/local/bin` and it should work: `mv lucky /usr/local/bin`.
 

--- a/src/actions/guides/getting-started/installing.cr
+++ b/src/actions/guides/getting-started/installing.cr
@@ -77,7 +77,7 @@ class Guides::GettingStarted::Installing < GuideAction
     * cd into the newly cloned directory
     * Check out latest [released version](https://github.com/luckyframework/lucky_cli/releases) `git checkout #{LuckyCliVersion.current_tag}`
     * Run `shards install`
-    * Run `crystal build --release src/lucky.cr`
+    * Run `crystal build src/lucky.cr`
     * Move the generated `lucky` binary to your path. Most of the time you can move
       it to `/usr/local/bin` and it should work: `mv lucky /usr/local/bin`.
 


### PR DESCRIPTION
Fixing a typo in the guide and adding a `--release` flag to the luck_cli build reference.