### PR TITLE
Fix browser auth documentation

### DIFF
--- a/src/actions/guides/authentication/browser_authentication.cr
+++ b/src/actions/guides/authentication/browser_authentication.cr
@@ -203,7 +203,7 @@ class Guides::Authentication::Browser < GuideAction
     Let's say we have this action that requires sign in:
 
     ```crystal
-    class Settings::Edit < MainLayout
+    class Settings::Edit < BrowserAction
       route do
         html Settings::EditPage
       end


### PR DESCRIPTION
The `Settings::Edit` action in documentation should inherit from `BrowserAction` instead of `MainLayout`

## Current Site
![Screen Shot 2019-12-26 at 7 14 24 PM](https://user-images.githubusercontent.com/17329408/71495550-0cf41080-2814-11ea-981f-13bcea08b9b9.png)
