### PR TITLE
Make common things a bit more visible in search

### DIFF
--- a/src/actions/guides/database/querying-deleting.cr
+++ b/src/actions/guides/database/querying-deleting.cr
@@ -180,7 +180,7 @@ class Guides::Database::QueryingDeleting < GuideAction
     UserQuery.new.age.nilable_eq(potential_age_or_nil_value)
     ```
 
-    ### A = B AND C = D
+    ### WHERE with AND (A = B AND C = D)
 
     Find rows where `A` is equal to `B` and `C` is equal to `D`.
 
@@ -206,7 +206,7 @@ class Guides::Database::QueryingDeleting < GuideAction
 
     ### A IS NULL / IS NOT NULL
 
-    Find rows where `A` is `nil`.
+    Find rows where `A` is `nil` using is_nil.
 
     `SELECT COLUMNS FROM users WHERE users.name IS NULL`
 
@@ -224,7 +224,12 @@ class Guides::Database::QueryingDeleting < GuideAction
 
     ### A gt/lt B
 
-    Find rows where `A` is greater than or equal to `B`.
+    * gt: >
+    * gte: >=
+    * lt: <
+    * lte: <=
+
+    Find rows where `A` is greater than or equal to (>=) `B`.
 
     `WHERE users.age >= 21`
 
@@ -381,7 +386,7 @@ class Guides::Database::QueryingDeleting < GuideAction
 
     ## Aggregates
 
-    ### Count
+    ### Select Count
 
     `SELECT COUNT(*) FROM users`
 
@@ -389,7 +394,7 @@ class Guides::Database::QueryingDeleting < GuideAction
     total_count = UserQuery.new.select_count
     ```
 
-    ### Avg / Sum
+    ### Select Avg / Sum
 
     `SELECT AVG(users.age) FROM users`
 
@@ -415,7 +420,7 @@ class Guides::Database::QueryingDeleting < GuideAction
     UserQuery.new.age.select_sum!
     ```
 
-    ### Min / Max
+    ### Select Min / Max
 
     `SELECT MIN(users.age) FROM users`
 

--- a/src/actions/guides/database/validating-saving.cr
+++ b/src/actions/guides/database/validating-saving.cr
@@ -31,14 +31,16 @@ class Guides::Database::ValidatingSaving < GuideAction
     user sign ups.
 
     #{permalink(ANCHOR_PERMITTING_COLUMNS)}
-    ## Allowing params to be saved
+    ## Allowing params to be saved with permit_columns
 
     By default you won’t be able to set any data from params. This is a security
-    measure to make sure that parameters can only be set that you want to allow
+    measure to make sure that parameters can only be set that you want to permit
     users to fill out. For example, you might not want your users to be able to
-    set an admin status through the `SaveUser` operation.
+    set an admin status through the `SaveUser` operation, but setting the
+    name is ok.
 
-    To allow users to set columns from JSON/form params, use the `permit_columns` macro:
+    To permit users to set columns from JSON or form params, use the
+    `permit_columns` macro:
 
     ```crystal
     # src/operations/save_user.cr
@@ -47,7 +49,7 @@ class Guides::Database::ValidatingSaving < GuideAction
     end
     ```
 
-    Now you will be able to fill out the user’s name from params.
+    Now you will be able to fill out the user’s name from request params.
 
     ## Creating records
 

--- a/src/posts/lucky_0.19.cr
+++ b/src/posts/lucky_0.19.cr
@@ -30,9 +30,9 @@ class Lucky019Release < BasePost
 
     ### Change tracking
 
-    Somtimes you want to perform an action only if certain attributes change, or
-    you may want to audit changes database attributes. This is now super easy
-    with the new change tracking methods in save operations:
+    Somtimes you want to perform an action only if certain attributes change,
+    or you may want to audit changes to database attributes. This is now
+    simple to do with the new change tracking methods on attributes:
 
     ```crystal
     class SaveUser < User::SaveOperation


### PR DESCRIPTION
By using words people use. Not the indexer does not index code, so using regular words is important