### PR TITLE
Work on a new HTML forms page.

### DIFF
--- a/src/actions/guides/database/validating-saving.cr
+++ b/src/actions/guides/database/validating-saving.cr
@@ -133,7 +133,6 @@ class Guides::Database::ValidatingSaving < GuideAction
         form_for Users::Create do
           label_for operation.name
           text_input operation.name
-          errors_for operation.name
 
           submit "Save User"
         end
@@ -141,9 +140,8 @@ class Guides::Database::ValidatingSaving < GuideAction
     end
     ```
 
-    > A private method `render_form` is extracted because it makes it easier to
-    reference the form as `op`. It also makes it easier to see what a page looks like
-    with a quick glance at the `content` method.
+    > A private method `render_form` is extracted because it makes it easier
+    > to see what a page looks like with a quick glance at the `content` method.
 
     ```crystal
     class Users::Create < BrowserAction
@@ -186,98 +184,12 @@ class Guides::Database::ValidatingSaving < GuideAction
     > params must be nested under the param key to be found. (e.g. HTML
     > `user:email=abc@example.com`, JSON `{"user":{"email":"abc@example.com"}}`)
 
-    ### Simplify inputs with `Shared::Field`
 
-    In the above form we had to write a fair amount of code to show a label, input,
-    and errors tag. Lucky generates a `Shared::Field` component that you can use
-    and customize to make this simpler. It is found in `src/components/shared/field.cr`
-    and is used in pages like this:
+    ### Form element inputs
 
-    ```crystal
-    # This will render a label, an input, and any errors for the 'name'
-    mount Shared::Field.new(op.name)
+    To see a list of all the different form element inputs, check out the
+    [HTML Forms](#{Guides::Frontend::HtmlForms.path}) guide.
 
-    # You can customize the generated input
-    mount Shared::Field.new(operation.email), &.email_input
-    mount Shared::Field.new(operation.email), &.email_input(autofocus: "true")
-    mount Shared::Field.new(operation.username), &.email_input(placeholder: "Username")
-
-    # You can append to or replace the HTML class on the input
-    mount Shared::Field.new(operation.name), &.text_input(append_class: "custom-input-class")
-    mount Shared::Field.new(operation.nickname), &.text_input(replace_class: "compact-input")
-    ```
-
-    Look in `src/components/shared/field.cr` to see even more options and customize
-    the generated markup.
-
-    > You can also duplicate and rename the component for different styles of input
-    > fields in your app. For example, you might have a `CompactField` component,
-    > or a `FieldWithoutLabel` component.
-
-    ### Select, email input, and other special inputs
-
-    The main inputs that you can use with Lucky:
-
-    * `text_input`
-    * `email_input`
-    * `color_input`
-    * `hidden_input`
-    * `number_input`
-    * `telephone_input`
-    * `url_input`
-    * `search_input`
-    * `password_input`
-    * `range_input`
-    * `textarea`
-
-    ```crystal
-    # Example using an email input
-    email_input op.email, optional_html_attributes: "anything"
-    ```
-
-    ### Submit
-
-    Call `submit` with the text to display
-
-    ```crystal
-    # In a page
-    submit "Text", optional_html_attributes: "anything you want"
-    ```
-
-    ### Checkboxes
-
-    ```crystal
-    # If checked, will set the `admin` column to true
-    checkbox op.admin, value: "true"
-    ```
-
-    ### Select with options
-
-    ```crystal
-    # Assuming you have an operation with a permitted category_id
-    select_input op.category_id do
-      options_for_select(op.category_id, categories_for_select)
-    end
-
-    private def categories_for_select
-      CategoryQuery.new.map do |category|
-        # The first element is the display name
-        # The second element is the value sent to the form
-        {category.title, category.id}
-      end
-    end
-    ```
-
-    ### Labels
-
-    ```crystal
-    label_for op.title # Will display "Title"
-    label_for op.title, "Custom Title" # Will display "Custom Title"
-    label_for op.title do
-      text "Custom Title"
-      strong "(required)"
-    end
-    ```
 
     ## Validating data
 
@@ -598,7 +510,7 @@ class Guides::Database::ValidatingSaving < GuideAction
 
       private def render_form(operation)
         form_for SignUps::Create do
-          # labels and errors_for omitted for brevity
+          # labels omitted for brevity
           text_input operation.name
           email_input operation.email
           password_input operation.password

--- a/src/actions/guides/frontend/html_forms.cr
+++ b/src/actions/guides/frontend/html_forms.cr
@@ -319,6 +319,9 @@ class Guides::Frontend::HtmlForms < GuideAction
 
     ## Select fields
 
+    For select fields, you'll use a combination of `select_tag` and the `options_for_select` methods.
+    The selected value will be determined by the current value of the attribute (i.e. `op.car_make`)
+
     ```html
     <select name="param_key:car_make" class="custom-select">
       <option value="1">Honda</option>
@@ -329,14 +332,25 @@ class Guides::Frontend::HtmlForms < GuideAction
     ```
 
     ```crystal
-    select(op.car_make, class: "custom-select") do
+    select_tag(op.car_make, class: "custom-select") do
       options_for_select(op.car_make, [{"Honda", 1}, {"Toyota", 2}, {"Ford", 3}, {"Volkswagen", 4}])
     end
     ```
 
-    ## Checboxes / Radios
+    The second argument to `options_for_select` takes an `Array(Tuple(String, String | Int32 | Int64))`. If your data is coming from a query, you can easily map that data in to this format.
 
-    ### Chechbox
+    ```crystal
+    # Use with `options_for_select(op.car_make, options_for_cars)`
+    private def options_for_cars
+      CarQuery.all.map do |car|
+        {car.make, car.id}
+      end
+    end
+    ```
+
+    ## Checkboxes / Radios
+
+    ### Checkbox
 
     The `checkbox` method will auto generate a secondary hidden input that will hold the
     unchecked value of your attribute. This allows params to still contain a value even if a

--- a/src/actions/guides/frontend/html_forms.cr
+++ b/src/actions/guides/frontend/html_forms.cr
@@ -7,7 +7,7 @@ class Guides::Frontend::HtmlForms < GuideAction
 
   def markdown : String
     <<-MD
-    ### Overview
+    ## Overview
 
     You can generate form tags like `<form>`, `<input>`, etc... using
     [methods like `form` and `input`](#{Guides::Frontend::RenderingHtml.path}),

--- a/src/actions/guides/frontend/html_forms.cr
+++ b/src/actions/guides/frontend/html_forms.cr
@@ -47,7 +47,7 @@ class Guides::Frontend::HtmlForms < GuideAction
     The Action class already has a route defined that defines which HTTP method to use (GET, PUT, etc.). When passing
     the action class in, Lucky will use the defined HTTP method automatically.
 
-    You can also pass in a route path if you need to pass in additional URL params.
+    You can also pass in a route path using `with` if the action requires params to be passed in.
 
     ```crystal
     form_for(Posts::Create.with(author_id: @current_user.id)) do

--- a/src/actions/guides/frontend/html_forms.cr
+++ b/src/actions/guides/frontend/html_forms.cr
@@ -44,7 +44,7 @@ class Guides::Frontend::HtmlForms < GuideAction
     end
     ```
 
-    The Action class already has a route defined that sets the HTTP METHOD. When passing
+    The Action class already has a route defined that defines which HTTP method to use (GET, PUT, etc.). When passing
     that class in, Lucky will know which method to set for you.
 
     You can also pass in a route path if you need to pass in additional URL params.

--- a/src/actions/guides/frontend/html_forms.cr
+++ b/src/actions/guides/frontend/html_forms.cr
@@ -66,7 +66,7 @@ class Guides::Frontend::HtmlForms < GuideAction
 
     ## Input fields
 
-    All of the input helper methods take an `Avram::Attribute`. These are created
+    All of the input helper methods take an `Avram::PermittedAttribute`. These are created
     from setting an `attribute` or `permit_columns` in your `Avram::Operation`.
     Then calling that attribute on the Operation.
     See the [Operations Guide](#{Guides::Database::ValidatingSaving.path}) for more info.

--- a/src/actions/guides/frontend/html_forms.cr
+++ b/src/actions/guides/frontend/html_forms.cr
@@ -45,7 +45,7 @@ class Guides::Frontend::HtmlForms < GuideAction
     ```
 
     The Action class already has a route defined that defines which HTTP method to use (GET, PUT, etc.). When passing
-    that class in, Lucky will know which method to set for you.
+    the action class in, Lucky will use the defined HTTP method automatically.
 
     You can also pass in a route path if you need to pass in additional URL params.
 

--- a/src/actions/guides/frontend/html_forms.cr
+++ b/src/actions/guides/frontend/html_forms.cr
@@ -405,15 +405,21 @@ class Guides::Frontend::HtmlForms < GuideAction
 
     ## Labels
 
+    The text will be derived from the name of the attribute.
+
     ```crystal
-    label_for(op.first_name)
+    label_for(op.first_name, class: "custom-label")
+    ```
 
-    # or with custom text
+    If you need custom text, you can pass it in as the second argument.
 
-    label_for(op.first_name, "Enter your First name:")
+    ```crystal
+    label_for(op.first_name, "Enter your First name:", class: "custom-label")
+    ```
 
-    # or using a block
+    or use a block for extra customization
 
+    ```crystal
     label_for(op.first_name) do
       strong("First Name: ")
     end

--- a/src/actions/guides/frontend/html_forms.cr
+++ b/src/actions/guides/frontend/html_forms.cr
@@ -428,7 +428,7 @@ class Guides::Frontend::HtmlForms < GuideAction
     # or using a block
 
     label_for(op.first_name) do
-      text("First Name: ")
+      strong("First Name: ")
     end
     ```
 

--- a/src/actions/guides/frontend/html_forms.cr
+++ b/src/actions/guides/frontend/html_forms.cr
@@ -1,0 +1,517 @@
+class Guides::Frontend::HtmlForms < GuideAction
+  guide_route "/frontend/html-forms"
+
+  def self.title
+    "HTML Forms"
+  end
+
+  def markdown : String
+    <<-MD
+    ### Working with Lucky's HTML builder
+
+    All HTML tags have an associated method based on the name of the tag, with the exception of a few.
+    (e.g. `<form></form>` - `form()`, `<button></button>` - `button()`, etc...)
+
+    These are the only HTML tags with an alias name method.
+
+    * `<select></select>` - `select_tag`
+    * `<p></p>` - `para`
+
+    > These are overridden as to not clash with built-in Crystal methods.
+
+    In addition to being able to specify any form element by calling that method, Lucky also
+    gives you access to some helper methods to make this easier. All of these methods will go
+    in your `content` method of your page, or in a component.
+
+    ## Form Tag
+
+    The `form_for` method takes any route or [Action Class](#{Guides::HttpAndRouting::RoutingAndParams.path}), any html options, and a block
+    to encompass the whole form.
+
+    As well as defining the `<form>` tag for you, the `form_for` method will also include an optional
+    `csrf_hidden_input` by default. To disable this option, look in your `config/form_helpers.cr`.
+
+    ```html
+    <form method="post" action="/posts" class="inline-form">
+      <input type="hidden" name="_csrf" value="some_token" />
+    </form>
+    ```
+
+    becomes
+
+    ```crystal
+    form_for(Posts::Create, class: "inline-form") do
+    end
+    ```
+
+    The Action class already has a route defined that sets the HTTP METHOD. When passing
+    that class in, Lucky will know which method to set for you.
+
+    You can also pass in a route path if you need to pass in additional URL params.
+
+    ```crystal
+    form_for(Posts::Create.with(author_id: @current_user.id)) do
+    end
+    ```
+
+    ### Custom forms
+
+    If you need more control over how your form is displayed, you can always use the `form`
+    method directly, and pass any options you'd like.
+
+    ```crystal
+    form(method: "get", class: "custom-form", action: Search::Index.path) do
+    end
+    ```
+
+    ## Input fields
+
+    All of the input helper methods take an `Avram::Attribute`. These are created
+    from setting an `attribute` or `permit_columns` in your `Avram::Operation`.
+    Then calling that attribute on the Operation.
+    See the [Operations Guide](#{Guides::Database::ValidatingSaving.path}) for more info.
+
+    > For these examples, `op` will refer to an instance of an `Avram::Operation`.
+
+    ### text input
+
+    ```html
+    <input type="text"
+           id="param_key_full_name"
+           name="param_key:full_name"
+           value=""
+           class="custom-input"
+           required />
+    ```
+
+    ```crystal
+    text_input(op.full_name, attrs: [:required], class: "custom-input")
+    ```
+
+    ### password input
+
+    ```html
+    <input type="password"
+           id="param_key_password"
+           name="param_key:password"
+           value=""
+           class="custom-input"
+           required />
+    ```
+
+    ```crystal
+    password_input(op.password, attrs: [:required], class: "custom-input")
+    ```
+
+    ### email input
+
+    ```html
+    <input type="email"
+           id="param_key_email"
+           name="param_key:email"
+           value=""
+           class="custom-input"
+           required />
+    ```
+
+    ```crystal
+    email_input(op.email, attrs: [:required], class: "custom-input")
+    ```
+
+    ### hidden input
+
+    ```html
+    <input type="hidden"
+           id="param_key_shh_secret"
+           name="param_key:shh_secret"
+           value=""
+           class="custom-input"
+           required />
+    ```
+
+    ```crystal
+    hidden_input(op.shh_secret, attrs: [:required], class: "custom-input")
+    ```
+
+    ### file input
+
+    ```html
+    <input type="file"
+           id="param_key_users_face"
+           name="param_key:users_face"
+           value=""
+           class="custom-input"
+           required />
+    ```
+
+    ```crystal
+    file_input(op.users_face, attrs: [:required], class: "custom-input")
+    ```
+
+    ### color input
+
+    ```html
+    <input type="color"
+           id="param_key_theme_color"
+           name="param_key:theme_color"
+           value=""
+           class="custom-input"
+           required />
+    ```
+
+    ```crystal
+    color_input(op.theme_color, attrs: [:required], class: "custom-input")
+    ```
+
+    ### number input
+
+    ```html
+    <input type="number"
+           id="param_key_score"
+           name="param_key:score"
+           value=""
+           class="custom-input"
+           min="0"
+           max="10"
+           required />
+    ```
+
+    ```crystal
+    number_input(op.score, attrs: [:required], class: "custom-input", min: "0", max: "10")
+    ```
+
+    ### url input
+
+    ```html
+    <input type="url"
+           id="param_key_website"
+           name="param_key:website"
+           value=""
+           class="custom-input"
+           required />
+    ```
+
+    ```crystal
+    url_input(op.website, attrs: [:required], class: "custom-input")
+    ```
+
+    ### search input
+
+    ```html
+    <input type="search"
+           id="param_key_search"
+           name="param_key:search"
+           value=""
+           class="custom-input"
+           required />
+    ```
+
+    ```crystal
+    search_input(op.search, attrs: [:required], class: "custom-input")
+    ```
+
+    ### range input
+
+    ```html
+    <input type="range"
+           id="param_key_distance"
+           name="param_key:distance"
+           value=""
+           class="custom-input"
+           min="0"
+           max="100"
+           step="10"
+           required />
+    ```
+
+    ```crystal
+    range_input(op.distance, attrs: [:required], class: "custom-input", min: "10", max: "100", step: "10")
+    ```
+
+    ### telephone input
+
+    ```html
+    <input type="tel"
+           id="param_key_mobile_num"
+           name="param_key:mobile_num"
+           value=""
+           class="custom-input"
+           pattern="[0-9]{3}-[0-9]{3}-[0-9]{4}"
+           required />
+    ```
+
+    ```crystal
+    telephone_input(op.mobile_num, attrs: [:required], class: "custom-input", pattern: "[0-9]{3}-[0-9]{3}-[0-9]{4}")
+    ```
+
+    ### time input
+
+    ```html
+    <input type="time"
+           id="param_key_appointment_time"
+           name="param_key:appointment_time"
+           value=""
+           class="custom-input"
+           required />
+    ```
+
+    ```crystal
+    time_input(op.appointment_time, attrs: [:required], class: "custom-input")
+    ```
+
+    ### date input
+
+    ```html
+    <input type="date"
+           id="param_key_anniversary"
+           name="param_key:anniversary"
+           value=""
+           class="custom-input"
+           required />
+    ```
+
+    ```crystal
+    date_input(op.anniversary, attrs: [:required], class: "custom-input")
+    ```
+
+    ### datetime input
+
+    ```html
+    <input type="datetime-local"
+           id="param_key_expired_at"
+           name="param_key:expired_at"
+           value=""
+           class="custom-input"
+           required />
+    ```
+
+    ```crystal
+    datetime_input(op.expired_at, attrs: [:required], class: "custom-input")
+    ```
+
+    > The `datetime` input generates a `type="datetime-local"`, and not `type="datetime"`.
+    > The [datetime input](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime)
+    > is deprecated in favor of the new one. As always, be sure to check browser support since
+    > these are still not fully recognized.
+
+    ### custom input
+
+    You can use the `input` method to craft any custom input you'd like.
+
+    ```html
+    <input type="text" value="taco" name="food" required />
+    ```
+
+    ```crystal
+    input(type: "text", value: "taco", name: "food", attrs: [:required])
+    ```
+
+    ## Textareas
+
+    ```html
+    <textarea id="param_key_content" name="param_key:content" rows="10" cols="20" readonly>
+    </textarea>
+    ```
+
+    ```crystal
+    textarea(op.content, attrs: [:readonly], rows: "10", cols: "20")
+    ```
+
+    ## Select fields
+
+    ```html
+    <select name="param_key:car_make" class="custom-select">
+      <option value="1">Honda</option>
+      <option value="2" selected="true">Toyota</option>
+      <option value="3">Ford</option>
+      <option value="4">Volkswagen</option>
+    </select>
+    ```
+
+    ```crystal
+    select(op.car_make, class: "custom-select") do
+      options_for_select(op.car_make, [{"Honda", 1}, {"Toyota", 2}, {"Ford", 3}, {"Volkswagen", 4}])
+    end
+    ```
+
+    ## Checboxes / Radios
+
+    ### Chechbox
+
+    The `checkbox` method will auto generate a secondary hidden input that will hold the
+    unchecked value of your attribute. This allows params to still contain a value even if a
+    checkbox is not checked.
+
+    ```html
+    <input type="hidden" name="param_key:with_cheese" value="no" />
+    <input type="checkbox"
+           id="param_key_with_cheese"
+           name="param_key:with_cheese"
+           value="yes"
+           class="custom-check"
+           checked="true" />
+    ```
+
+    ```crystal
+    checkbox(op.with_cheese, "no", "yes", class: "custom-check")
+    ```
+
+    ### Radio
+
+    ```html
+    <input type="radio"
+           name="param_key:question_five"
+           value="Yes" />
+    <input type="radio"
+           name="param_key:question_five"
+           value="No" />
+    ```
+
+    ```crystal
+    input(op.question_five, type: "radio", name: "\#{op.param_key}:\#{op.question_five.name}", value: "Yes")
+    input(op.question_five, type: "radio", name: "\#{op.param_key}:\#{op.question_five.name}", value: "No")
+    ```
+
+    > ISSUE REF: https://github.com/luckyframework/lucky/issues/1023
+
+    ## Buttons
+
+    ### button tag
+
+    ```html
+    <button role="submit" class="btn">Go!</button>
+    ```
+
+    ```crystal
+    button("Go!", role: "submit", class: "btn")
+    ```
+
+    ### submit input
+
+    ```html
+    <input type="submit" value="Go!" class="btn" />
+    ```
+
+    ```crystal
+    submit("Go!", class: "btn")
+    ```
+
+    ## Labels
+
+    ```html
+    <label for="param_key_first_name" class="custom-label">First Name</label>
+    ```
+
+    ```crystal
+    label_for(op.first_name)
+
+    # or with custom text
+
+    label_for(op.first_name, "Enter your First name:")
+
+    # or using a block
+
+    label_for(op.first_name) do
+      text("First Name: ")
+    end
+    ```
+
+    ## Saving Data
+
+    HTML Forms in Lucky are based around the concept of [Operations](#{Guides::Database::ValidatingSaving.path}). We use these for securing param values from form inputs, and doing validations.
+
+    For info on interacting with databases, see the [saving
+    data with operations](#{Guides::Database::ValidatingSaving.path(anchor: Guides::Database::ValidatingSaving::ANCHOR_USING_WITH_HTML_FORMS)}) guide.
+
+    ## Displaying Errors
+
+    If your permitted column / attribute fail any sort of validation, it's common to
+    display an error about why it failed. For this, Lucky generates a component you can use
+    in `src/components/shared/field_errors.cr`.
+
+    ```html
+    <div class="error">Email must be valid</div>
+    ```
+
+    ```crystal
+    mount Shared::FieldErrors.new(op.email)
+    ```
+
+    ## Simple Example
+
+    ```crystal
+    # src/operations/save_post.cr
+    class SavePost < Post::SaveOperation
+      permit_columns title, body, released_at, draft
+    end
+
+    # src/pages/posts/edit_page.cr
+    class Posts::EditPage < MainLayout
+      needs op : SavePost
+
+      def content
+        form_for(Posts::Update) do
+          para do
+            label_for(@op.title)
+            text_input(@op.title)
+            error_for(@op.title)
+          end
+
+          para do
+            label_for(@op.body)
+            textarea(@op.body)
+            error_for(@op.body)
+          end
+
+          para do
+            label_for(@op.released_at)
+            datetime_input(@op.released_at)
+            error_for(@op.released_at)
+          end
+
+          para do
+            label_for(@op.draft, "Mark as Draft?")
+            checkbox(@op.draft)
+            error_for(@op.draft)
+          end
+
+          submit("Update Post", class: "btn")
+        end
+      end
+
+      private def error_for(field)
+        mount Shared::FieldErrors.new(field)
+      end
+    end
+    ```
+
+    ## Shared Components
+
+    In the above form we had to write a fair amount of code to show a label, input, and error.
+    Lucky generates a `Shared::Field` component that you can use and customize to make
+    this simpler. It is found in `src/components/shared/field.cr`, and is used in pages
+    like this:
+
+    ```crystal
+    # This will render a label, an input, and any validation errors for the 'name'
+    mount Shared::Field.new(op.name)
+
+    # You can customize the generated input
+    mount Shared::Field.new(operation.email), &.email_input
+    mount Shared::Field.new(operation.email), &.email_input(autofocus: "true")
+    mount Shared::Field.new(operation.username), &.email_input(placeholder: "Username")
+
+    # You can append to or replace the HTML class on the input
+    mount Shared::Field.new(operation.name), &.text_input(append_class: "custom-input-class")
+    mount Shared::Field.new(operation.nickname), &.text_input(replace_class: "compact-input")
+    ```
+
+    Look in `src/components/shared/field.cr` to see even more options and customize
+    the generated markup.
+
+    > You can also duplicate and rename the component for different styles of input
+    > fields in your app. For example, you might have a `CompactField` component,
+    > or a `FieldWithoutLabel` component.
+    MD
+  end
+end

--- a/src/actions/guides/frontend/html_forms.cr
+++ b/src/actions/guides/frontend/html_forms.cr
@@ -60,7 +60,7 @@ class Guides::Frontend::HtmlForms < GuideAction
 
     All of the input helper methods take an `Avram::PermittedAttribute`. These are created
     from declaring an `attribute` or `permit_columns` in your `Avram::Operation`.
-    See the [Operations Guide](#{Guides::Database::ValidatingSaving.path}) for more info.
+    See the [Operations Guide](#{Guides::Database::ValidatingSaving.path(anchor: Guides::Database::ValidatingSaving::ANCHOR_PERMITTING_COLUMNS)}) for more info.
 
     > For these examples, `op` will refer to an instance of an `Avram::Operation` (e.g. `SaveUser`).
 

--- a/src/actions/guides/frontend/html_forms.cr
+++ b/src/actions/guides/frontend/html_forms.cr
@@ -23,7 +23,7 @@ class Guides::Frontend::HtmlForms < GuideAction
     gives you access to some helper methods to make this easier. All of these methods will go
     in your `content` method of your page, or in a component.
 
-    ## Form Tag
+    ## Form tag
 
     The `form_for` method takes any route or [Action Class](#{Guides::HttpAndRouting::RoutingAndParams.path}), any html options, and a block
     to encompass the whole form.
@@ -307,6 +307,8 @@ class Guides::Frontend::HtmlForms < GuideAction
     ```
 
     ## Textareas
+
+    The content of the `<textarea>` will come from the value of the attribute (i.e. `op.content`)
 
     ```html
     <textarea id="param_key_content" name="param_key:content" rows="10" cols="20" readonly>

--- a/src/actions/guides/frontend/html_forms.cr
+++ b/src/actions/guides/frontend/html_forms.cr
@@ -7,21 +7,13 @@ class Guides::Frontend::HtmlForms < GuideAction
 
   def markdown : String
     <<-MD
-    ### Working with Lucky's HTML builder
+    ### Overview
 
-    All HTML tags have an associated method based on the name of the tag, with the exception of a few.
-    (e.g. `<form></form>` - `form()`, `<button></button>` - `button()`, etc...)
+    You can generate form tags like `<form>`, `<input>`, etc... using
+    [methods like `form` and `input`](#{Guides::Frontend::RenderingHtml.path}),
+    but the recommended way is to use Lucky's form helpers.
 
-    These are the only HTML tags with an alias name method.
-
-    * `<select></select>` - `select_tag`
-    * `<p></p>` - `para`
-
-    > These are overridden as to not clash with built-in Crystal methods.
-
-    In addition to being able to specify any form element by calling that method, Lucky also
-    gives you access to some helper methods to make this easier. All of these methods will go
-    in your `content` method of your page, or in a component.
+    All of these methods will go in your `content` method of your page, or in a component.
 
     ## Form tag
 
@@ -31,17 +23,17 @@ class Guides::Frontend::HtmlForms < GuideAction
     As well as defining the `<form>` tag for you, the `form_for` method will also include an optional
     `csrf_hidden_input` by default. To disable this option, look in your `config/form_helpers.cr`.
 
+    ```crystal
+    form_for(Posts::Create, class: "inline-form") do
+    end
+    ```
+
+    Will generate this
+
     ```html
     <form method="post" action="/posts" class="inline-form">
       <input type="hidden" name="_csrf" value="some_token" />
     </form>
-    ```
-
-    becomes
-
-    ```crystal
-    form_for(Posts::Create, class: "inline-form") do
-    end
     ```
 
     The Action class already has a route defined that defines which HTTP method to use (GET, PUT, etc.). When passing
@@ -67,13 +59,16 @@ class Guides::Frontend::HtmlForms < GuideAction
     ## Input fields
 
     All of the input helper methods take an `Avram::PermittedAttribute`. These are created
-    from setting an `attribute` or `permit_columns` in your `Avram::Operation`.
-    Then calling that attribute on the Operation.
+    from declaring an `attribute` or `permit_columns` in your `Avram::Operation`.
     See the [Operations Guide](#{Guides::Database::ValidatingSaving.path}) for more info.
 
-    > For these examples, `op` will refer to an instance of an `Avram::Operation`.
+    > For these examples, `op` will refer to an instance of an `Avram::Operation` (e.g. `SaveUser`).
 
     ### text input
+
+    ```crystal
+    text_input(op.full_name, attrs: [:required], class: "custom-input")
+    ```
 
     ```html
     <input type="text"
@@ -84,11 +79,11 @@ class Guides::Frontend::HtmlForms < GuideAction
            required />
     ```
 
-    ```crystal
-    text_input(op.full_name, attrs: [:required], class: "custom-input")
-    ```
-
     ### password input
+
+    ```crystal
+    password_input(op.password, attrs: [:required], class: "custom-input")
+    ```
 
     ```html
     <input type="password"
@@ -99,11 +94,11 @@ class Guides::Frontend::HtmlForms < GuideAction
            required />
     ```
 
-    ```crystal
-    password_input(op.password, attrs: [:required], class: "custom-input")
-    ```
-
     ### email input
+
+    ```crystal
+    email_input(op.email, attrs: [:required], class: "custom-input")
+    ```
 
     ```html
     <input type="email"
@@ -114,11 +109,11 @@ class Guides::Frontend::HtmlForms < GuideAction
            required />
     ```
 
-    ```crystal
-    email_input(op.email, attrs: [:required], class: "custom-input")
-    ```
-
     ### hidden input
+
+    ```crystal
+    hidden_input(op.shh_secret, attrs: [:required], class: "custom-input")
+    ```
 
     ```html
     <input type="hidden"
@@ -129,11 +124,11 @@ class Guides::Frontend::HtmlForms < GuideAction
            required />
     ```
 
-    ```crystal
-    hidden_input(op.shh_secret, attrs: [:required], class: "custom-input")
-    ```
-
     ### file input
+
+    ```crystal
+    file_input(op.users_face, attrs: [:required], class: "custom-input")
+    ```
 
     ```html
     <input type="file"
@@ -144,11 +139,11 @@ class Guides::Frontend::HtmlForms < GuideAction
            required />
     ```
 
-    ```crystal
-    file_input(op.users_face, attrs: [:required], class: "custom-input")
-    ```
-
     ### color input
+
+    ```crystal
+    color_input(op.theme_color, attrs: [:required], class: "custom-input")
+    ```
 
     ```html
     <input type="color"
@@ -159,11 +154,11 @@ class Guides::Frontend::HtmlForms < GuideAction
            required />
     ```
 
-    ```crystal
-    color_input(op.theme_color, attrs: [:required], class: "custom-input")
-    ```
-
     ### number input
+
+    ```crystal
+    number_input(op.score, attrs: [:required], class: "custom-input", min: "0", max: "10")
+    ```
 
     ```html
     <input type="number"
@@ -176,11 +171,11 @@ class Guides::Frontend::HtmlForms < GuideAction
            required />
     ```
 
-    ```crystal
-    number_input(op.score, attrs: [:required], class: "custom-input", min: "0", max: "10")
-    ```
-
     ### url input
+
+    ```crystal
+    url_input(op.website, attrs: [:required], class: "custom-input")
+    ```
 
     ```html
     <input type="url"
@@ -191,11 +186,11 @@ class Guides::Frontend::HtmlForms < GuideAction
            required />
     ```
 
-    ```crystal
-    url_input(op.website, attrs: [:required], class: "custom-input")
-    ```
-
     ### search input
+
+    ```crystal
+    search_input(op.search, attrs: [:required], class: "custom-input")
+    ```
 
     ```html
     <input type="search"
@@ -206,11 +201,11 @@ class Guides::Frontend::HtmlForms < GuideAction
            required />
     ```
 
-    ```crystal
-    search_input(op.search, attrs: [:required], class: "custom-input")
-    ```
-
     ### range input
+
+    ```crystal
+    range_input(op.distance, attrs: [:required], class: "custom-input", min: "10", max: "100", step: "10")
+    ```
 
     ```html
     <input type="range"
@@ -224,11 +219,11 @@ class Guides::Frontend::HtmlForms < GuideAction
            required />
     ```
 
-    ```crystal
-    range_input(op.distance, attrs: [:required], class: "custom-input", min: "10", max: "100", step: "10")
-    ```
-
     ### telephone input
+
+    ```crystal
+    telephone_input(op.mobile_num, attrs: [:required], class: "custom-input", pattern: "[0-9]{3}-[0-9]{3}-[0-9]{4}")
+    ```
 
     ```html
     <input type="tel"
@@ -240,11 +235,11 @@ class Guides::Frontend::HtmlForms < GuideAction
            required />
     ```
 
-    ```crystal
-    telephone_input(op.mobile_num, attrs: [:required], class: "custom-input", pattern: "[0-9]{3}-[0-9]{3}-[0-9]{4}")
-    ```
-
     ### time input
+
+    ```crystal
+    time_input(op.appointment_time, attrs: [:required], class: "custom-input")
+    ```
 
     ```html
     <input type="time"
@@ -255,11 +250,11 @@ class Guides::Frontend::HtmlForms < GuideAction
            required />
     ```
 
-    ```crystal
-    time_input(op.appointment_time, attrs: [:required], class: "custom-input")
-    ```
-
     ### date input
+
+    ```crystal
+    date_input(op.anniversary, attrs: [:required], class: "custom-input")
+    ```
 
     ```html
     <input type="date"
@@ -270,11 +265,11 @@ class Guides::Frontend::HtmlForms < GuideAction
            required />
     ```
 
-    ```crystal
-    date_input(op.anniversary, attrs: [:required], class: "custom-input")
-    ```
-
     ### datetime input
+
+    ```crystal
+    datetime_input(op.expired_at, attrs: [:required], class: "custom-input")
+    ```
 
     ```html
     <input type="datetime-local"
@@ -283,10 +278,6 @@ class Guides::Frontend::HtmlForms < GuideAction
            value=""
            class="custom-input"
            required />
-    ```
-
-    ```crystal
-    datetime_input(op.expired_at, attrs: [:required], class: "custom-input")
     ```
 
     > The `datetime` input generates a `type="datetime-local"`, and not `type="datetime"`.
@@ -298,31 +289,37 @@ class Guides::Frontend::HtmlForms < GuideAction
 
     You can use the `input` method to craft any custom input you'd like.
 
-    ```html
-    <input type="text" value="taco" name="food" required />
-    ```
-
     ```crystal
     input(type: "text", value: "taco", name: "food", attrs: [:required])
+    ```
+
+    ```html
+    <input type="text" value="taco" name="food" required />
     ```
 
     ## Textareas
 
     The content of the `<textarea>` will come from the value of the attribute (i.e. `op.content`)
 
+    ```crystal
+    textarea(op.content, attrs: [:readonly], rows: "10", cols: "20")
+    ```
+
     ```html
     <textarea id="param_key_content" name="param_key:content" rows="10" cols="20" readonly>
     </textarea>
-    ```
-
-    ```crystal
-    textarea(op.content, attrs: [:readonly], rows: "10", cols: "20")
     ```
 
     ## Select fields
 
     For select fields, you'll use a combination of `select_tag` and the `options_for_select` methods.
     The selected value will be determined by the current value of the attribute (i.e. `op.car_make`)
+
+    ```crystal
+    select_tag(op.car_make, class: "custom-select") do
+      options_for_select(op.car_make, [{"Honda", 1}, {"Toyota", 2}])
+    end
+    ```
 
     ```html
     <select name="param_key:car_make" class="custom-select">
@@ -331,12 +328,6 @@ class Guides::Frontend::HtmlForms < GuideAction
       <option value="3">Ford</option>
       <option value="4">Volkswagen</option>
     </select>
-    ```
-
-    ```crystal
-    select_tag(op.car_make, class: "custom-select") do
-      options_for_select(op.car_make, [{"Honda", 1}, {"Toyota", 2}, {"Ford", 3}, {"Volkswagen", 4}])
-    end
     ```
 
     The second argument to `options_for_select` takes an `Array(Tuple(String, String | Int32 | Int64))`. If your data is coming from a query, you can easily map that data in to this format.
@@ -358,6 +349,10 @@ class Guides::Frontend::HtmlForms < GuideAction
     unchecked value of your attribute. This allows params to still contain a value even if a
     checkbox is not checked.
 
+    ```crystal
+    checkbox(op.with_cheese, "no", "yes", class: "custom-check")
+    ```
+
     ```html
     <input type="hidden" name="param_key:with_cheese" value="no" />
     <input type="checkbox"
@@ -368,11 +363,12 @@ class Guides::Frontend::HtmlForms < GuideAction
            checked="true" />
     ```
 
-    ```crystal
-    checkbox(op.with_cheese, "no", "yes", class: "custom-check")
-    ```
-
     ### Radio
+
+    ```crystal
+    input(op.question_five, type: "radio", name: "\#{op.param_key}:\#{op.question_five.name}", value: "Yes")
+    input(op.question_five, type: "radio", name: "\#{op.param_key}:\#{op.question_five.name}", value: "No")
+    ```
 
     ```html
     <input type="radio"
@@ -383,40 +379,31 @@ class Guides::Frontend::HtmlForms < GuideAction
            value="No" />
     ```
 
-    ```crystal
-    input(op.question_five, type: "radio", name: "\#{op.param_key}:\#{op.question_five.name}", value: "Yes")
-    input(op.question_five, type: "radio", name: "\#{op.param_key}:\#{op.question_five.name}", value: "No")
-    ```
-
     > ISSUE REF: https://github.com/luckyframework/lucky/issues/1023
 
     ## Buttons
 
     ### button tag
 
-    ```html
-    <button role="submit" class="btn">Go!</button>
-    ```
-
     ```crystal
     button("Go!", role: "submit", class: "btn")
     ```
 
-    ### submit input
-
     ```html
-    <input type="submit" value="Go!" class="btn" />
+    <button role="submit" class="btn">Go!</button>
     ```
+
+    ### submit input
 
     ```crystal
     submit("Go!", class: "btn")
     ```
 
-    ## Labels
-
     ```html
-    <label for="param_key_first_name" class="custom-label">First Name</label>
+    <input type="submit" value="Go!" class="btn" />
     ```
+
+    ## Labels
 
     ```crystal
     label_for(op.first_name)
@@ -432,6 +419,10 @@ class Guides::Frontend::HtmlForms < GuideAction
     end
     ```
 
+    ```html
+    <label for="param_key_first_name" class="custom-label">First Name</label>
+    ```
+
     ## Saving Data
 
     HTML Forms in Lucky are based around the concept of [Operations](#{Guides::Database::ValidatingSaving.path}). We use these for securing param values from form inputs, and doing validations.
@@ -441,16 +432,16 @@ class Guides::Frontend::HtmlForms < GuideAction
 
     ## Displaying Errors
 
-    If your permitted column / attribute fail any sort of validation, it's common to
+    If your permitted column / attribute fails any sort of validation, it's common to
     display an error about why it failed. For this, Lucky generates a component you can use
     in `src/components/shared/field_errors.cr`.
 
-    ```html
-    <div class="error">Email must be valid</div>
-    ```
-
     ```crystal
     mount Shared::FieldErrors.new(op.email)
+    ```
+
+    ```html
+    <div class="error">Email must be valid</div>
     ```
 
     ## Simple Example
@@ -458,7 +449,7 @@ class Guides::Frontend::HtmlForms < GuideAction
     ```crystal
     # src/operations/save_post.cr
     class SavePost < Post::SaveOperation
-      permit_columns title, body, released_at, draft
+      permit_columns title, body
     end
 
     # src/pages/posts/edit_page.cr
@@ -477,18 +468,6 @@ class Guides::Frontend::HtmlForms < GuideAction
             label_for(@op.body)
             textarea(@op.body)
             error_for(@op.body)
-          end
-
-          para do
-            label_for(@op.released_at)
-            datetime_input(@op.released_at)
-            error_for(@op.released_at)
-          end
-
-          para do
-            label_for(@op.draft, "Mark as Draft?")
-            checkbox(@op.draft)
-            error_for(@op.draft)
           end
 
           submit("Update Post", class: "btn")

--- a/src/actions/guides/frontend/rendering_html.cr
+++ b/src/actions/guides/frontend/rendering_html.cr
@@ -241,7 +241,10 @@ class Guides::Frontend::RenderingHtml < GuideAction
 
     ### Rendering HTML forms
 
-    There are some helpers for rendering HTML forms. For more info see the [saving
+    Lucky gives you lots of helper methods to make working with forms easier.
+    See the [rendering HTML forms](#{Guides::Frontend::HtmlForms.path}) guide to learn more.
+
+    For info on interacting with databases, see the [saving
     data with operations](#{Guides::Database::ValidatingSaving.path(anchor: Guides::Database::ValidatingSaving::ANCHOR_USING_WITH_HTML_FORMS)}) guide.
 
     ### Other special helpers

--- a/src/models/guides_list.cr
+++ b/src/models/guides_list.cr
@@ -22,6 +22,7 @@ class GuidesList
       ] of GuideAction.class),
       GuideCategory.new("Frontend", [
         Guides::Frontend::RenderingHtml,
+        Guides::Frontend::HtmlForms,
         Guides::Frontend::AssetHandling,
         Guides::Frontend::Internationalization,
         Guides::Frontend::Testing,


### PR DESCRIPTION
Fixes #193
Fixes #183 

There's a lot going on here, so I don't want to merge just yet, but please look over it and add suggestions. 

The current documentation for building HTML forms is located in the "Validating and Saving" section of "Database". It kind of makes sense because you use forms to save data, and we tie this stuff in to Operations. However, lots of people new to Lucky won't think "How do I do a select form? oh, let me look under database...". Since this is HTML related, I wanted to dedicate an entire page on the front end section to showing all of the methods we have, and how to use them. 

This will be the initial version of this page, but eventually I see this including more complex examples, and talking about doing associations and such.

I've also removed *some* of the html mentions from the validating page, though, I think because there's cross-over between them, it's ok to show some parts. It's like the HTML forms page shows the html side, and then links to the operations, where the validations page shows from the operations side and links to the HTML page. 

Last note was we had some mentions of things like `errors_for` which doesn't exist anymore