### PR TITLE
Replace `Authentication` with `Authorization` header in CORS example code

### DIFF
--- a/src/actions/guides/json_and_apis/cors.cr
+++ b/src/actions/guides/json_and_apis/cors.cr
@@ -66,7 +66,7 @@ class Guides::JsonAndApis::Cors < GuideAction
         context.response.headers["Access-Control-Allow-Origin"] = "*"
         context.response.headers["Access-Control-Allow-Credentials"] = "true"
         context.response.headers["Access-Control-Allow-Methods"] = "POST,GET,OPTIONS"
-        context.response.headers["Access-Control-Allow-Headers"] = "DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authentication"
+        context.response.headers["Access-Control-Allow-Headers"] = "DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization"
 
         # If this is an OPTIONS call, respond with just the needed headers and
         # respond with an empty response.
@@ -137,7 +137,7 @@ class Guides::JsonAndApis::Cors < GuideAction
         context.response.headers["Access-Control-Allow-Origin"] = allowed_origin?(request_origin) ? request_origin : ""
         context.response.headers["Access-Control-Allow-Credentials"] = "true"
         context.response.headers["Access-Control-Allow-Methods"] = "POST,GET,OPTIONS"
-        context.response.headers["Access-Control-Allow-Headers"] = "DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authentication"
+        context.response.headers["Access-Control-Allow-Headers"] = "DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization"
 
         # If this is an OPTIONS call, respond with just the needed headers.
         if context.request.method == "OPTIONS"


### PR DESCRIPTION
Using the standard `Authorization` header instead of `Authentication` in the example code might prevent errors for people using it in an API-only server (like me, lol)—especially since it's so far back in the line. If `Authentication` was intended: Sorry and feel free to just close this PR!