### PR TITLE
Ducoument dynamic_asset

### DIFF
--- a/src/actions/guides/frontend/asset-handling.cr
+++ b/src/actions/guides/frontend/asset-handling.cr
@@ -107,6 +107,13 @@ class Guides::Frontend::AssetHandling < GuideAction
     Note that assets are checked at compile time so if it is not found, Lucky will
     let you know. It will also let you know if you had a typo and suggest an asset
     that is close to what you typed.
+    
+    If the path of the asset is only known at runtime, you can use the `dynamic_asset`
+    helper instead.
+    
+    ```crystal
+    img src: dynamic_asset("images/\#{name}.png")
+    ```
 
     ### Using assets outside of pages and components
 


### PR DESCRIPTION
In the assets fronted guide the `dynamic_asset` function was not mentioned anywhere.

Given that I just stumbled on [this issue](https://github.com/luckyframework/lucky/issues/269) after encountering this problem, I thought it would be a good idea to add a line about it.