### PR TITLE
Adding a new query section for calling the reset methods. 

### DIFF
--- a/src/actions/guides/database/querying-deleting.cr
+++ b/src/actions/guides/database/querying-deleting.cr
@@ -668,7 +668,7 @@ class Guides::Database::QueryingDeleting < GuideAction
     > Avram is designed to be type-safe. You should use caution when using the non type-safe methods,
     > or raw SQL.
 
-    ## Reseting Queries
+    ## Resetting Queries
 
     If you need to remove parts of the SQL query after the query has been built, Avram gives you
     a few reset methods for that.
@@ -679,17 +679,18 @@ class Guides::Database::QueryingDeleting < GuideAction
     from your query.
 
     ```crystal
+    # SELECT * FROM users WHERE name = 'Billy' AND signed_up < '2 days ago'
     user_query = UserQuery.new.name("Billy").signed_up.lt(2.days.ago)
 
-    # This will only remove the `name = 'Billy'` from the WHERE clause
-    # SELECT * FROM users WHERE signed_up < ?
+    # The `name = 'Billy'` is removed
+    # SELECT * FROM users WHERE signed_up < '2 days ago'
     user_query.reset_where(&.name)
     ```
 
     ### Reset order
 
     ```crystal
-    user_query = UserQuery.new.signed_up.lt(2.days.ago).age.desc_order
+    user_query = UserQuery.new.age.desc_order
 
     # This will remove the `ORDER BY age DESC`
     user_query.reset_order

--- a/src/actions/guides/database/querying-deleting.cr
+++ b/src/actions/guides/database/querying-deleting.cr
@@ -668,6 +668,51 @@ class Guides::Database::QueryingDeleting < GuideAction
     > Avram is designed to be type-safe. You should use caution when using the non type-safe methods,
     > or raw SQL.
 
+    ## Reseting Queries
+
+    If you need to remove parts of the SQL query after the query has been built, Avram gives you
+    a few reset methods for that.
+
+    ### Reset where
+
+    The `reset_where` method takes a block where you call the name of the column you want to remove
+    from your query.
+
+    ```crystal
+    user_query = UserQuery.new.name("Billy").signed_up.lt(2.days.ago)
+
+    # This will only remove the `name = 'Billy'` from the WHERE clause
+    # SELECT * FROM users WHERE signed_up < ?
+    user_query.reset_where(&.name)
+    ```
+
+    ### Reset order
+
+    ```crystal
+    user_query = UserQuery.new.signed_up.lt(2.days.ago).age.desc_order
+
+    # This will remove the `ORDER BY age DESC`
+    user_query.reset_order
+    ```
+
+    ### Reset limit
+
+    ```crystal
+    user_query = UserQuery.new.limit(10)
+
+    # This will remove the `LIMIT 10`
+    user_query.reset_limit
+    ```
+
+    ### Reset offset
+
+    ```crystal
+    user_query = UserQuery.new.offset(25)
+
+    # This will remove the `OFFSET 25`
+    user_query.reset_offset
+    ```
+
     ## Debugging Queries
 
     Sometimes you may need to double check that the query you wrote outputs the SQL you expect.


### PR DESCRIPTION
Fixes #243

We actually didn't have `reset_order` documented either, so I decided to just add a new section. This includes `reset_where`, `reset_order`, `reset_limit`, and `reset_offset`. 

Now, technically, we already have the limit and offset resets documented, but in a future PR when adding in the pagination stuff, that section will be chopped up. Now that we have a dedicated section, we can expand when we have other things like reset_distinct, or reset_select. 