### PR TITLE
Adding new reload model guide

### DIFF
--- a/src/actions/guides/database/querying-deleting.cr
+++ b/src/actions/guides/database/querying-deleting.cr
@@ -1,5 +1,6 @@
 class Guides::Database::QueryingDeleting < GuideAction
   ANCHOR_PRELOADING = "perma-preloading"
+  ANCHOR_RELOADING = "perma-reloading"
   guide_route "/database/querying-deleting"
 
   def self.title
@@ -556,6 +557,7 @@ class Guides::Database::QueryingDeleting < GuideAction
     task.user!
     ```
 
+    #{permalink(ANCHOR_RELOADING)}
     ## Reloading
 
     Reloading a model can be useful when you've loaded a model, but then there is a change to the data.

--- a/src/actions/guides/database/querying-deleting.cr
+++ b/src/actions/guides/database/querying-deleting.cr
@@ -556,6 +556,53 @@ class Guides::Database::QueryingDeleting < GuideAction
     task.user!
     ```
 
+    ## Reloading
+
+    Reloading a model can be useful when you've loaded a model, but then there is a change to the data.
+
+    ```crystal
+    author = AuthorQuery.find(5)
+
+    # Let's say the Author's profile picture is hidden
+    author.hide_face #=> true
+
+    # If this database value is updated...
+    SaveAuthor.update!(author, hide_face: false)
+
+    # We can reload to get the new value
+    author.reload.hide_face #=> false
+    ```
+
+    When calling the `reload` method on the [model](#{Guides::Database::Models.path}), the original
+    instance is not updated.
+
+    ```crystal
+    # The new value grabbed from the reloaded model
+    author.reload.hide_face #=> false
+
+    # The original value is still in place
+    author.hide_face #=> true
+    ```
+
+    ### Reloading with preloading
+
+    You can also use the `reload` method to preload associations. For example, if you
+    have a post, and want to get the comments preloaded, you can use `reload` with a block. This
+    will help you with performance by avoiding N+1 performance issues.
+
+    ```crystal
+    post = PostQuery.first
+
+    # This is not preloaded, and can lead to performance issues
+    post.comments
+
+    # Preload the comments for better performance
+    post.reload(&.preload_comments).comments
+    ```
+
+    Read up on [preloading associations](#{Guides::Database::QueryingDeleting.path(anchor: Guides::Database::QueryingDeleting::ANCHOR_PRELOADING)})
+    for more information.
+
     ## No results
 
     Avram gives you a `none` method to return no results. This can be helpful when under

--- a/src/actions/guides/database/querying.cr
+++ b/src/actions/guides/database/querying.cr
@@ -558,7 +558,7 @@ class Guides::Database::Querying < GuideAction
     ```
 
     #{permalink(ANCHOR_RELOADING)}
-    ## Reloading
+    ## Reloading Data
 
     Reloading a model can be useful when you've loaded a model, but then there is a change to the data.
 
@@ -566,13 +566,13 @@ class Guides::Database::Querying < GuideAction
     author = AuthorQuery.find(5)
 
     # Let's say the Author's profile picture is hidden
-    author.hide_face #=> true
+    author.hide_avatar #=> true
 
     # If this database value is updated...
-    SaveAuthor.update!(author, hide_face: false)
+    SaveAuthor.update!(author, hide_avatar: false)
 
     # We can reload to get the new value
-    author.reload.hide_face #=> false
+    author.reload.hide_avatar #=> false
     ```
 
     When calling the `reload` method on the [model](#{Guides::Database::Models.path}), the original
@@ -580,29 +580,30 @@ class Guides::Database::Querying < GuideAction
 
     ```crystal
     # The new value grabbed from the reloaded model
-    author.reload.hide_face #=> false
+    author.reload.hide_avatar #=> false
 
     # The original value is still in place
-    author.hide_face #=> true
+    author.hide_avatar #=> true
     ```
 
-    ### Reloading with preloading
+    ### Adding preloads when reloading
 
     You can also use the `reload` method to preload associations. For example, if you
-    have a post, and want to get the comments preloaded, you can use `reload` with a block. This
-    will help you with performance by avoiding N+1 performance issues.
+    have a post, and want to preload comments, you can use `reload` with a block.
 
     ```crystal
-    post = PostQuery.first
+    # `post` is a recently updated record.
+    # We want to get all of the author names that commented on this `post`.
 
     # This is not preloaded, and can lead to performance issues
-    post.comments
+    post.comments.map(&.author.name)
 
-    # Preload the comments for better performance
-    post.reload(&.preload_comments).comments
+    # Preload the comments and authors for better performance
+    post.reload(&.preload_comments(CommentQuery.new.preload_authors))
+      .comments.map(&.author.name)
     ```
 
-    Read up on [preloading associations](#{Guides::Database::QueryingDeleting.path(anchor: Guides::Database::QueryingDeleting::ANCHOR_PRELOADING)})
+    Read up on [preloading associations](#{Guides::Database::Querying.path(anchor: Guides::Database::Querying::ANCHOR_PRELOADING)})
     for more information.
 
     ## No results

--- a/src/actions/guides/testing/creating_test_data.cr
+++ b/src/actions/guides/testing/creating_test_data.cr
@@ -173,15 +173,16 @@ class Guides::Testing::CreatingTestData < GuideAction
 
       SavePost.update!(post, title: "New Post Title")
 
-      # We still have our original value
+      # The `post` still has the original data
       post.title.should eq "Custom Post"
 
-      # Now we have the new value
-      post.reload.title.should eq "New Post Title"
+      # Reloading returns a new model with the updated data
+      updated_post = post.reload
+      updated_post.title.should eq "New Post Title"
     end
     ```
 
-    Read up on [reloading models](#{Guides::Database::QueryingDeleting.path(anchor: Guides::Database::QueryingDeleting::ANCHOR_RELOADING)})
+    Read up on [reloading models](#{Guides::Database::Querying.path(anchor: Guides::Database::Querying::ANCHOR_RELOADING)})
     for more information.
     MD
   end

--- a/src/actions/guides/testing/creating_test_data.cr
+++ b/src/actions/guides/testing/creating_test_data.cr
@@ -162,6 +162,27 @@ class Guides::Testing::CreatingTestData < GuideAction
       end
     end
     ```
+
+    ### Reloading model data
+
+    If you've made a change to your data, you can call `reload` to get the updated data.
+
+    ```crystal
+    it "updates a post title" do
+      post = PostBox.create &.title("Custom Post")
+
+      SavePost.update!(post, title: "New Post Title")
+
+      # We still have our original value
+      post.title.should eq "Custom Post"
+
+      # Now we have the new value
+      post.reload.title.should eq "New Post Title"
+    end
+    ```
+
+    Read up on [reloading models](#{Guides::Database::QueryingDeleting.path(anchor: Guides::Database::QueryingDeleting::ANCHOR_RELOADING)})
+    for more information.
     MD
   end
 end


### PR DESCRIPTION
Fixes #242

This adds a new section for reloading to the query guide. It also mentions how to add in your preloads after you have your model. I've also added a small section to testing with an example of reloading your model after you've updated it during a spec.