### PR TITLE
Added new guide on soft deletes

### DIFF
--- a/src/actions/guides/database/deleting_records.cr
+++ b/src/actions/guides/database/deleting_records.cr
@@ -143,7 +143,7 @@ class Guides::Database::DeletingRecords < GuideAction
     ### Default queries without soft deleted
 
     If you want to filter out soft deleted records by default, it's really easy to do.
-    Just add the `only_kept` method to your `initialize`.
+    Just add the `only_kept` method to an `initialize` method.
 
     ```crystal
     class ArticleQuery < Article::BaseQuery

--- a/src/actions/guides/database/deleting_records.cr
+++ b/src/actions/guides/database/deleting_records.cr
@@ -142,7 +142,7 @@ class Guides::Database::DeletingRecords < GuideAction
 
     ### Default queries without soft deleted
 
-    If you want to skip all of your soft deleted records by default, it's really easy to do.
+    If you want to filter out soft deleted records by default, it's really easy to do.
     Just add the `only_kept` method to your `initialize`.
 
     ```crystal

--- a/src/actions/guides/database/deleting_records.cr
+++ b/src/actions/guides/database/deleting_records.cr
@@ -1,0 +1,169 @@
+class Guides::Database::DeletingRecords < GuideAction
+  guide_route "/database/deleting-records"
+
+  def self.title
+    "Deleting records"
+  end
+
+  def markdown : String
+    <<-MD
+    ## Deleting Records
+
+    ### Delete one
+
+    Deleting a single record is actually done on the [model](#{Guides::Database::Models.path}) directly.
+    Since each query returns an instance of the model, you can just call `delete` on that record.
+
+    ```crystal
+    user = UserQuery.find(4)
+
+    # DELETE FROM users WHERE users.id = 4
+    user.delete
+    ```
+
+    ### Bulk delete
+
+    If you need to bulk delete a group of records based on a where query, you can use `delete` at
+    the end of your query. This returns the number of records deleted.
+
+    ```crystal
+    # DELETE FROM users WHERE banned_at IS NOT NULL
+    UserQuery.new.banned_at.is_not_nil.delete
+    ```
+
+    ## Soft Deletes
+
+    A "soft delete" is when you want to hide a record as if it were deleted, but you want to keep the actual
+    record in your database. This allows you to restore the record without losing any previous data or associations.
+
+    Avram comes with some built-in modules to help working with soft deleted records a lot easier. Let's add it
+    to an existing `Article` model.
+
+    * We need to add a new `soft_deleted_at : Time?` column to our table that we want soft deletes.
+
+    ```
+    # Run this in your terminal
+    lucky gen.migration AddSoftDeleteToArticle
+    ```
+
+    * Open your new `db/migrations/#{Time.utc.to_s("%Y%m%d%H%I%S")}_add_soft_delete_to_article.cr` file.
+
+    ```crystal
+    def migrate
+      alter table_for(Article) do
+        add soft_deleted_at : Time?
+      end
+    end
+    ```
+
+    * Now open your `src/models/article.cr` file.
+
+    ```crystal
+    class Article < BaseModel
+      # Include this module
+      include Avram::SoftDelete::Model
+
+      table do
+        # Add this to your table
+        column soft_deleted_at : Time?
+      end
+    end
+    ```
+
+    * Next you just need to update `src/queries/article_query.cr`.
+
+    ```crystal
+    class ArticleQuery < Article::BaseQuery
+      # Add this module
+      include Avram::SoftDelete::Query
+    end
+    ```
+
+    ### Marking a record as soft deleted
+
+    Your model instance will now have a `soft_delete` method to mark that record as soft deleted, as well as,
+    a `soft_deleted?` method to check if the record has been marked as soft deleted.
+
+    ```crystal
+    article = ArticleQuery.first
+
+    # Check to see if soft_deleted_at is present
+    article.soft_deleted? #=> false
+
+    # Save the record as soft deleted
+    article.soft_delete
+
+    # Reload the model to get the new value
+    article.reload.soft_deleted? #=> true
+    ```
+
+    ### Marking all records as soft deleted
+
+    You can bulk update a group of records as soft deleted with the `soft_delete` method called on a Query object
+    instead of the model directly.
+
+    ```crystal
+    articles_to_delete = ArticleQuery.new.created_at.gt(3.years.ago)
+
+    # Marks only the articles created over 3 years ago as soft deleted
+    articles_to_delete.soft_delete
+    ```
+
+    ### Restore a soft deleted record
+
+    If you need to restore a soft deleted record, you can use the `restore` method.
+
+    ```crystal
+    # Set the `soft_deleted_at` back to `nil`
+    article.restore
+    ```
+
+    ### Restoring all soft deleted records
+
+    The same as bulk updating records as soft deleted, we can also bulk update to restore them with
+    the `restore` method.
+
+    ```crystal
+    articles_to_restore = ArticleQuery.new.only_soft_deleted
+
+    # Restore all of the soft deleted records
+    articles_to_restore.restore
+    ```
+
+    ### Query soft deleted records
+
+    ```crystal
+    # Return all articles that are not soft deleted
+    ArticleQuery.new.only_kept
+
+    # Return all articles that are soft deleted
+    ArticleQuery.new.only_soft_deleted
+
+    # Return all articles whether soft deleted or not
+    ArticleQuery.new.with_soft_deleted
+    ```
+
+    ## Truncating
+
+    ### Truncate table
+
+    If you need to delete every record in the entire table, you can use `truncate`.
+
+    `TRUNCATE TABLE users`
+
+    ```crystal
+    UserQuery.truncate
+    ```
+
+    ### Truncate database
+
+    You can also truncate your entire database by calling `truncate` on your database class.
+
+    ```crystal
+    AppDatabase.truncate
+    ```
+
+    > This method is great for tests; horrible for production. Also note this method is not chainable.
+    MD
+  end
+end

--- a/src/actions/guides/database/intro_to_avram_and_orms.cr
+++ b/src/actions/guides/database/intro_to_avram_and_orms.cr
@@ -58,7 +58,7 @@ class Guides::Database::IntroToAvramAndORMs < GuideAction
     Lucky will create a `User::BaseQuery` class for you, and your `UserQuery` object will inherit from that.
     (e.g. `UserQuery < User::BaseQuery`).
 
-    [Learn more about queries](#{Guides::Database::QueryingDeleting.path})
+    [Learn more about queries](#{Guides::Database::Querying.path})
 
     ## Operations
 

--- a/src/actions/guides/database/models.cr
+++ b/src/actions/guides/database/models.cr
@@ -35,7 +35,7 @@ class Guides::Database::Models < GuideAction
 
     * [User model](##{ANCHOR_SETTING_UP_A_MODEL}) - Located in `./src/models/user.cr`
     * [SaveUser Operation](#{Guides::Database::ValidatingSaving.path}) - Located in `./src/operations/save_user.cr`
-    * [User query](#{Guides::Database::QueryingDeleting.path}) - Located in `./src/queries/user_query.cr`
+    * [User query](#{Guides::Database::Querying.path}) - Located in `./src/queries/user_query.cr`
     * [User migration](#{Guides::Database::Migrations.path}) - Location in `./db/migrations/#{Time.utc.to_s("%Y%m%d%H%I%S")}_create_users.cr`
 
     #{permalink(ANCHOR_SETTING_UP_A_MODEL)}
@@ -386,7 +386,7 @@ class Guides::Database::Models < GuideAction
     ### Preloading polymorphic associations
 
     Since the polymorphic associations are just regular `belongs_to` associations with some sweet
-    helper methods, all of the [preloading](#{Guides::Database::QueryingDeleting.path(anchor: Guides::Database::QueryingDeleting::ANCHOR_PRELOADING)}) still exists.
+    helper methods, all of the [preloading](#{Guides::Database::Querying.path(anchor: Guides::Database::Querying::ANCHOR_PRELOADING)}) still exists.
 
     ```crystal
     comment = CommentQuery.new.preload_commentable

--- a/src/actions/guides/database/querying.cr
+++ b/src/actions/guides/database/querying.cr
@@ -1,9 +1,9 @@
-class Guides::Database::QueryingDeleting < GuideAction
+class Guides::Database::Querying < GuideAction
   ANCHOR_PRELOADING = "perma-preloading"
-  guide_route "/database/querying-deleting"
+  guide_route "/database/querying-records"
 
   def self.title
-    "Querying and Deleting records"
+    "Querying records"
   end
 
   def markdown : String
@@ -617,48 +617,6 @@ class Guides::Database::QueryingDeleting < GuideAction
         .where_tasks(task_query, auto_inner_join: false)
     end
     ```
-
-    ## Deleting Records
-
-    ### Delete one
-
-    Deleting a single record is actually done on the [model](#{Guides::Database::Models.path}) directly. Since each query returns an
-    instance of the model, you can just call `delete` on that record.
-
-    ```crystal
-    user = UserQuery.find(4)
-
-    # DELETE FROM users WHERE users.id = 4
-    user.delete
-    ```
-
-    ### Bulk delete
-
-    If you need to bulk delete a group of records based on a where query, you can use `delete` at
-    the end of your query. This returns the number of records deleted.
-
-    ```crystal
-    # DELETE FROM users WHERE banned_at IS NOT NULL
-    UserQuery.new.banned_at.is_not_nil.delete
-    ```
-
-    ### Truncate
-
-    If you need to delete every record in the entire table, you can use `truncate`.
-
-    `TRUNCATE TABLE users`
-
-    ```crystal
-    UserQuery.truncate
-    ```
-
-    You can also truncate your entire database by calling `truncate` on your database class.
-
-    ```crystal
-    AppDatabase.truncate
-    ```
-
-    > This method is great for tests; horrible for production. Also note this method is not chainable.
 
     ## Complex Queries
 

--- a/src/actions/guides/database/validating-saving.cr
+++ b/src/actions/guides/database/validating-saving.cr
@@ -18,7 +18,7 @@ class Guides::Database::ValidatingSaving < GuideAction
     filled. `{ModelName}::SaveOperation` automatically defines an attribute for each model field.
 
     We’ll be using the migration and model from the [Querying
-    guide](#{Guides::Database::QueryingDeleting.path}). Once you have that set up, let’s set
+    guide](#{Guides::Database::Querying.path}). Once you have that set up, let’s set
     up a save operation:
 
     ```crystal

--- a/src/actions/guides/getting-started/concepts.cr
+++ b/src/actions/guides/getting-started/concepts.cr
@@ -32,7 +32,7 @@ class Guides::GettingStarted::Concepts < GuideAction
     2. Lucky routes the request to a matching [Action](#{Guides::HttpAndRouting::RoutingAndParams.path}).
       * In Lucky, [an Action defines what HTTP method and path it handles](#{Guides::HttpAndRouting::RoutingAndParams.path}).
     3. Action processes the request. For example:
-      * [Query the database with Avram](#{Guides::Database::QueryingDeleting.path}).
+      * [Query the database with Avram](#{Guides::Database::Querying.path}).
       * [Create or update db records with Avram](#{Guides::Database::ValidatingSaving.path}).
       * [Send an email with Carbon](#{Guides::Emails::SendingEmailsWithCarbon.path}).
     4. The Action generates a response for the browser or client. For example:

--- a/src/actions/guides/getting-started/why_lucky.cr
+++ b/src/actions/guides/getting-started/why_lucky.cr
@@ -24,7 +24,7 @@ class Guides::GettingStarted::WhyLucky < GuideAction
 
     ## Spend less time writing tests and debugging
 
-    [Type safe database queries](#{Guides::Database::QueryingDeleting.path}), [rock solid
+    [Type safe database queries](#{Guides::Database::Querying.path}), [rock solid
     routing](#{Guides::HttpAndRouting::RoutingAndParams.path}), [type safe forms and
     validations](#{Guides::Database::ValidatingSaving.path}), and more. This is how Lucky helps you
     find errors before they reach your customers, write fewer tests, and spend less

--- a/src/handlers/legacy_redirect_handler.cr
+++ b/src/handlers/legacy_redirect_handler.cr
@@ -8,7 +8,7 @@ class LegacyRedirectHandler
     "/guides/database-migrations"                 => Guides::Database::Migrations,
     "/guides/actions-and-routing"                 => Guides::HttpAndRouting::RoutingAndParams,
     "/guides/rendering-html"                      => Guides::Frontend::RenderingHtml,
-    "/guides/querying-the-database"               => Guides::Database::QueryingDeleting,
+    "/guides/querying-the-database"               => Guides::Database::Querying,
     "/guides/custom-queries"                      => Guides::Database::RawSql,
     "/guides/saving-with-forms"                   => Guides::Database::ValidatingSaving,
     "/guides/asset-handling"                      => Guides::Frontend::AssetHandling,
@@ -24,7 +24,8 @@ class LegacyRedirectHandler
     "/guides/authentication"                      => Guides::Authentication::Intro,
     "/guides/deploying-heroku"                    => Guides::Deploying::Heroku,
     "/guides/database/validating-saving-deleting" => Guides::Database::ValidatingSaving,
-    "/guides/database/querying"                   => Guides::Database::QueryingDeleting,
+    "/guides/database/querying"                   => Guides::Database::Querying,
+    "/guides/database/querying-deleting"          => Guides::Database::Querying,
   }
 
   def call(context)

--- a/src/models/guides_list.cr
+++ b/src/models/guides_list.cr
@@ -31,8 +31,9 @@ class GuidesList
         Guides::Database::DatabaseSetup,
         Guides::Database::Migrations,
         Guides::Database::Models,
-        Guides::Database::QueryingDeleting,
+        Guides::Database::Querying,
         Guides::Database::ValidatingSaving,
+        Guides::Database::DeletingRecords,
         Guides::Database::RawSql,
       ] of GuideAction.class),
       GuideCategory.new("JSON and APIs", [


### PR DESCRIPTION
Fixes #245

This PR moves the deleting guide out of querying and in to its own home. It also adds in the new Soft Delete API.

I decided to move it to its own page since the Query page is starting to get larger, and will soon be even larger with some more additions coming. Plus, this guide is pretty heft with the new soft deletes. 