### PR TITLE
Remove crenv recommendation

### DIFF
--- a/src/actions/guides/getting-started/installing.cr
+++ b/src/actions/guides/getting-started/installing.cr
@@ -27,16 +27,22 @@ class Guides::GettingStarted::Installing < GuideAction
 
     ### 3. Configure SSL for Crystal
 
-    You'll need to add `export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig`
-    to your `~/.bash_profile` or `~/.zshrc` so Crystal can use SSL through the
-    openssl package.
+    You'll need to add tell Crystal how to find OpenSSL by adding an `export`
+    to your `~/.bash_profile` or `~/.zshrc`.
 
-    ```shell
-    # For Bash, the default shell on MacOS
-    echo 'export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig' >>~/.bash_profile
+    > You can run `echo $SHELL` in your terminal if you're not sure whether you
+      are using ZSH or Bash.
 
-    # For ZSH
+    **For ZSH (the default as of macOS Catalina):**
+
+    ```plain
     echo 'export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig' >>~/.zshrc
+    ```
+
+    **For Bash:**
+
+    ```plain
+    echo 'export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig' >>~/.bash_profile
     ```
 
     > If you get an error like this: "Package libssl/libcrypto was not found in the

--- a/src/actions/guides/getting-started/installing.cr
+++ b/src/actions/guides/getting-started/installing.cr
@@ -61,12 +61,28 @@ class Guides::GettingStarted::Installing < GuideAction
 
     ### 1. Install Crystal
 
-    **We recommend using a version manager** to make sure the correct
-    version of Crystal is used with Lucky.
-    Try [crenv](https://github.com/pine/crenv) (recommended) or
-    [asdf-crystal](https://github.com/marciogm/asdf-crystal) (great if you already use [asdf](https://github.com/asdf-vm/asdf))
+    **Using asdf version manager:**
 
-    Alternatively you could [install Crystal without a version manager](https://crystal-lang.org/reference/installation/).
+    We recommend using a version manager to make sure the correct version of
+    Crystal is used with Lucky.
+
+    * [Install asdf](https://asdf-vm.com/#/core-manage-asdf-vm)
+    * Install the [asdf-crystal](https://github.com/marciogm/asdf-crystal) plugin:
+
+    ```plain
+    asdf plugin-add crystal https://github.com/asdf-community/asdf-crystal.git
+    ```
+
+    * Set up `asdf` so it uses the `.crystal-version` file to determine which version to use:
+
+    ```plain
+    echo "legacy_version_file = yes" >>~/.asdfrc
+    ```
+
+    **Or, install Crystal without a version manager**
+
+    If you can't get asdf installed or don't want to use a version manager,
+    you can [install Crystal without a version manager](https://crystal-lang.org/reference/installation/).
 
     ### 2. Check installation
 


### PR DESCRIPTION
crenv is not actively maintained, and currently fails to install 0.34

asdf is more stable the asdf-crystal is part of asdf-community which has
more reviewers and maintainers.