### PR TITLE
Fix select fields documentation

### DIFF
--- a/src/actions/guides/frontend/html_forms.cr
+++ b/src/actions/guides/frontend/html_forms.cr
@@ -326,8 +326,6 @@ class Guides::Frontend::HtmlForms < GuideAction
     <select name="param_key:car_make" class="custom-select">
       <option value="1">Honda</option>
       <option value="2" selected="true">Toyota</option>
-      <option value="3">Ford</option>
-      <option value="4">Volkswagen</option>
     </select>
     ```
 


### PR DESCRIPTION
The options are determined by the passed in array of options. There were two more options in the HTML than what were in the Crystal code.