### PR TITLE
Install crystal globally using asdf

### DIFF
--- a/src/actions/guides/getting-started/installing.cr
+++ b/src/actions/guides/getting-started/installing.cr
@@ -84,6 +84,24 @@ class Guides::GettingStarted::Installing < GuideAction
     ```plain
     echo "legacy_version_file = yes" >>~/.asdfrc
     ```
+    
+    * Install Crystal with `asdf`.
+    
+    ```plain
+    asdf install crystal latest
+    ```
+    
+    * See which version of crystal was installed
+    
+    ```plain
+    asdf list crystal
+    ```
+    
+    * Set global version of crystal to that version (0.34.0 is used as an example)
+    
+    ```plain
+    asdf global crystal 0.34.0
+    ```
 
     **Or, install Crystal without a version manager**
 


### PR DESCRIPTION
OS: Ubuntu 18.04.2 LTS on WSL 1

When following the instructions for Linux, Crystal is not installed.

In addition, at the `shards install` step for installing lucky_cli if Crystal is not installed globally in asdf then the following error will appear
```
asdf: No version set for command shards
you might want to add one of the following in your .tool-versions file:
crystal 0.34.0
```

An alternative solution would be to add instructions for the user to create a `.tool-versions` file in the `lucky_cli` folder.

Also, when attempting to build lucky, I received the following error:

```
crystal build src/lucky.cr
/usr/bin/ld: cannot find -lpcre (this usually means you need to install the development package for libpcre)
collect2: error: ld returned 1 exit status
Error: execution of command failed with code: 1: `cc "${@}" -o '/home/name/.cache/crystal/mnt-c-Users-name-Development-lucky_cli-lib-teeplate-src-lib-file_tree-macros-directory.cr/macro_run'  -rdynamic  -lpcre -lm /home/name/.asdf/installs/crystal/0.34.0/bin/../lib/crystal/lib/libgc.a -lpthread /home/name/.asdf/installs/crystal/0.34.0/share/crystal/src/ext/libcrystal.a -levent -lrt -ldl -L/home/name/.asdf/installs/crystal/0.34.0/bin/../lib/crystal/lib -L/home/name/.asdf/installs/crystal/0.34.0/bin/../lib/crystal/lib`
```
I resolved this by running: `sudo apt install libpcre3-dev`. I didn't add it to the PR because I wasn't sure if this prerequisite was specific to running on WSL.
