### PR TITLE
Update Guides with dynamic Crystal Version

### DIFF
--- a/src/actions/guides/getting-started/installing.cr
+++ b/src/actions/guides/getting-started/installing.cr
@@ -63,7 +63,7 @@ class Guides::GettingStarted::Installing < GuideAction
     dnf install glibc-devel libevent-devel pcre2-devel openssl-devel libyaml-devel zlib-devel libpng-devel
     ```
 
-    ## Crystal v0.34.0
+    ## Crystal v#{LuckyCliVersion.compatible_crystal_version}
 
     ### 1. Install Crystal
 
@@ -97,10 +97,10 @@ class Guides::GettingStarted::Installing < GuideAction
     asdf list crystal
     ```
     
-    * Set global version of crystal to that version (0.34.0 is used as an example)
+    * Set global version of crystal to that version (#{LuckyCliVersion.compatible_crystal_version} is used as an example)
     
     ```plain
-    asdf global crystal 0.34.0
+    asdf global crystal #{LuckyCliVersion.compatible_crystal_version}
     ```
 
     **Or, install Crystal without a version manager**
@@ -114,7 +114,7 @@ class Guides::GettingStarted::Installing < GuideAction
     crystal -v
     ```
 
-    Should return at least `0.34.0`
+    Should return at least `#{LuckyCliVersion.compatible_crystal_version}`
 
     ## Install Lucky CLI on macOS
 

--- a/src/models/lucky_cli_version.cr
+++ b/src/models/lucky_cli_version.cr
@@ -8,4 +8,8 @@ module LuckyCliVersion
   def current_version : String
     "0.21.0"
   end
+
+  def compatible_crystal_version : String
+    "0.34.0"
+  end
 end


### PR DESCRIPTION
The Crystal version is used in a few spots for the installing guide. Moved this value to a method so it's easier to update later. 