### PR TITLE
Fix typo in custom tasks.

### DIFF
--- a/src/actions/guides/command_line_tasks/custom_tasks.cr
+++ b/src/actions/guides/command_line_tasks/custom_tasks.cr
@@ -17,7 +17,7 @@ class Guides::CommandLineTasks::CustomTasks < GuideAction
 
     ```crystal
     # tasks/generate_sitemaps.cr
-    class GenerateSitemaps < LuckCli::Task
+    class GenerateSitemaps < LuckyCli::Task
       summary "Generate the sitemap.xml for this site"
 
       def call


### PR DESCRIPTION
Just noticed this while copy/pasting the code.