### PR TITLE
Fixing converting HTML comments in converter tool.

### DIFF
--- a/spec/converter_spec.cr
+++ b/spec/converter_spec.cr
@@ -229,6 +229,43 @@ describe HTML2Lucky::Converter do
 
     output.should eq_html %q(para "Hello")
   end
+
+  describe "converting comments" do
+    it "does not render a comment" do
+      input = "<!-- this comment -->"
+      output = HTML2Lucky::Converter.new(input).convert
+
+      output.should eq ""
+    end
+
+    it "strips comments from inside of tags" do
+      input = "<div><!-- secret --><span>the man</span></div>"
+      output = HTML2Lucky::Converter.new(input).convert
+
+      output.should eq_html <<-CODE
+      div do
+        span "the man"
+      end
+      CODE
+    end
+
+    it "handles multiline comments" do
+      input = <<-HTML
+      <div>one</div>
+      <!--
+      comment here
+      and more stuff here
+      -->
+      <div>two</div>
+      HTML
+      output = HTML2Lucky::Converter.new(input).convert
+
+      output.should eq_html <<-CODE
+      div "one"
+      div "two"
+      CODE
+    end
+  end
 end
 
 private def eq_html(html)

--- a/vendor/html2lucky/tags/comment_tag.cr
+++ b/vendor/html2lucky/tags/comment_tag.cr
@@ -1,5 +1,4 @@
 class HTML2Lucky::CommentTag < HTML2Lucky::Tag
-
   def print_io(io) : IO
     io
   end

--- a/vendor/html2lucky/tags/comment_tag.cr
+++ b/vendor/html2lucky/tags/comment_tag.cr
@@ -1,0 +1,6 @@
+class HTML2Lucky::CommentTag < HTML2Lucky::Tag
+
+  def print_io(io) : IO
+    io
+  end
+end

--- a/vendor/html2lucky/tags/tag_factory.cr
+++ b/vendor/html2lucky/tags/tag_factory.cr
@@ -1,5 +1,5 @@
 class HTML2Lucky::TagFactory
-  TEXT_TAG_NAME = "-text"
+  TEXT_TAG_NAME    = "-text"
   COMMENT_TAG_NAME = "_comment"
 
   getter depth, tag

--- a/vendor/html2lucky/tags/tag_factory.cr
+++ b/vendor/html2lucky/tags/tag_factory.cr
@@ -1,5 +1,6 @@
 class HTML2Lucky::TagFactory
   TEXT_TAG_NAME = "-text"
+  COMMENT_TAG_NAME = "_comment"
 
   getter depth, tag
 
@@ -13,6 +14,8 @@ class HTML2Lucky::TagFactory
   private def tag_class : Tag.class
     if text_tag?(tag)
       TextTag
+    elsif comment_tag?(tag)
+      CommentTag
     elsif single_line_tag?(tag)
       SingleLineTag
     else
@@ -31,5 +34,9 @@ class HTML2Lucky::TagFactory
 
   def text_tag?(tag)
     tag.tag_name == TEXT_TAG_NAME
+  end
+
+  def comment_tag?(tag)
+    tag.tag_name == COMMENT_TAG_NAME
   end
 end


### PR DESCRIPTION
 Fixes #357

Originally I was thinking maybe render them as `raw`, but we might as well just strip them completely so you can add Crystal comments in yourself instead 😅 