### PR TITLE
Change to shorter /html URL

### DIFF
--- a/src/actions/converter/index.cr
+++ b/src/actions/converter/index.cr
@@ -1,8 +1,0 @@
-class ConvertHtmlToLucky::Index < BrowserAction
-  get "/convert-html-to-lucky" do
-    html IndexPage,
-      title: "Convert HTML to Lucky",
-      input: "",
-      output: ""
-  end
-end

--- a/src/actions/guides/frontend/rendering_html.cr
+++ b/src/actions/guides/frontend/rendering_html.cr
@@ -15,7 +15,7 @@ class Guides::Frontend::RenderingHtml < GuideAction
     Lucky uses Crystal methods for rendering HTML. The Crystal methods map
     as closely as possible to how HTML is used. To help with the transition
     we also have a small app for [converting HTML to
-    Lucky methods](#{ConvertHtmlToLucky::Index.path}).
+    Lucky methods](#{HtmlConversions::New.path}).
 
     Using Lucky HTML adds an additional layer of type-safety, is
     auto-formatted with Crystal's formatter, and can be much easier to

--- a/src/actions/html_conversions/create.cr
+++ b/src/actions/html_conversions/create.cr
@@ -1,10 +1,10 @@
-class ConvertHtmlToLucky::Create < BrowserAction
+class HtmlConversions::Create < BrowserAction
   param input : String = ""
 
-  post "/convert-html-to-lucky" do
+  post "/html" do
     output = HTML2Lucky::Converter.new(input).convert
 
-    html IndexPage,
+    html NewPage,
       title: "Convert HTML to Lucky",
       input: input,
       output: output

--- a/src/actions/html_conversions/new.cr
+++ b/src/actions/html_conversions/new.cr
@@ -1,0 +1,8 @@
+class HtmlConversions::New < BrowserAction
+  get "/html" do
+    html NewPage,
+      title: "Convert HTML to Lucky",
+      input: "",
+      output: ""
+  end
+end

--- a/src/handlers/legacy_redirect_handler.cr
+++ b/src/handlers/legacy_redirect_handler.cr
@@ -1,40 +1,41 @@
 class LegacyRedirectHandler
   include HTTP::Handler
   REDIRECTS = {
-    "/guides"                                     => Guides::GettingStarted::Installing,
-    "/guides/overview"                            => Guides::GettingStarted::Concepts,
-    "/guides/installing"                          => Guides::GettingStarted::Installing,
-    "/guides/configuration"                       => Guides::GettingStarted::Configuration,
-    "/guides/database-migrations"                 => Guides::Database::Migrations,
-    "/guides/actions-and-routing"                 => Guides::HttpAndRouting::RoutingAndParams,
-    "/guides/rendering-html"                      => Guides::Frontend::RenderingHtml,
-    "/guides/querying-the-database"               => Guides::Database::Querying,
-    "/guides/custom-queries"                      => Guides::Database::RawSql,
-    "/guides/saving-with-forms"                   => Guides::Database::ValidatingSaving,
-    "/guides/asset-handling"                      => Guides::Frontend::AssetHandling,
-    "/guides/tasks"                               => Guides::CommandLineTasks::BuiltIn,
-    "/guides/logging-and-error-handling"          => Guides::GettingStarted::Logging,
-    "/guides/writing-json-apis"                   => Guides::JsonAndApis::RenderingJson,
-    "/guides/json-and-apis/handling-errors"       => Guides::HttpAndRouting::ErrorHandling,
-    "/guides/generating-test-data"                => Guides::Testing::CreatingTestData,
-    "/guides/database/testing"                    => Guides::Testing::CreatingTestData,
-    "/guides/browser-tests"                       => Guides::Testing::HtmlAndInteractivity,
-    "/guides/frontend/testing"                    => Guides::Testing::HtmlAndInteractivity,
-    "/guides/sending-emails"                      => Guides::Emails::SendingEmailsWithCarbon,
-    "/guides/authentication"                      => Guides::Authentication::Intro,
-    "/guides/deploying-heroku"                    => Guides::Deploying::Heroku,
-    "/guides/database/validating-saving-deleting" => Guides::Database::ValidatingSaving,
-    "/guides/database/querying"                   => Guides::Database::Querying,
-    "/guides/database/querying-deleting"          => Guides::Database::Querying,
+    "/convert-html-to-lucky"                      => HtmlConversions::New.url,
+    "/guides"                                     => Guides::GettingStarted::Installing.url,
+    "/guides/overview"                            => Guides::GettingStarted::Concepts.url,
+    "/guides/installing"                          => Guides::GettingStarted::Installing.url,
+    "/guides/configuration"                       => Guides::GettingStarted::Configuration.url,
+    "/guides/database-migrations"                 => Guides::Database::Migrations.url,
+    "/guides/actions-and-routing"                 => Guides::HttpAndRouting::RoutingAndParams.url,
+    "/guides/rendering-html"                      => Guides::Frontend::RenderingHtml.url,
+    "/guides/querying-the-database"               => Guides::Database::Querying.url,
+    "/guides/custom-queries"                      => Guides::Database::RawSql.url,
+    "/guides/saving-with-forms"                   => Guides::Database::ValidatingSaving.url,
+    "/guides/asset-handling"                      => Guides::Frontend::AssetHandling.url,
+    "/guides/tasks"                               => Guides::CommandLineTasks::BuiltIn.url,
+    "/guides/logging-and-error-handling"          => Guides::GettingStarted::Logging.url,
+    "/guides/writing-json-apis"                   => Guides::JsonAndApis::RenderingJson.url,
+    "/guides/json-and-apis/handling-errors"       => Guides::HttpAndRouting::ErrorHandling.url,
+    "/guides/generating-test-data"                => Guides::Testing::CreatingTestData.url,
+    "/guides/database/testing"                    => Guides::Testing::CreatingTestData.url,
+    "/guides/browser-tests"                       => Guides::Testing::HtmlAndInteractivity.url,
+    "/guides/frontend/testing"                    => Guides::Testing::HtmlAndInteractivity.url,
+    "/guides/sending-emails"                      => Guides::Emails::SendingEmailsWithCarbon.url,
+    "/guides/authentication"                      => Guides::Authentication::Intro.url,
+    "/guides/deploying-heroku"                    => Guides::Deploying::Heroku.url,
+    "/guides/database/validating-saving-deleting" => Guides::Database::ValidatingSaving.url,
+    "/guides/database/querying"                   => Guides::Database::Querying.url,
+    "/guides/database/querying-deleting"          => Guides::Database::Querying.url,
   }
 
   def call(context)
     response = context.response
     path = context.request.path.rchop('/')
-    if new_route = REDIRECTS[path]?
+    if new_url = REDIRECTS[path]?
       Lucky::Log.dexter.info { {handled_by: LegacyRedirectHandler.name} }
       response.status_code = HTTP::Status::MOVED_PERMANENTLY.value
-      response.headers["Location"] = new_route.url
+      response.headers["Location"] = new_url
       return
     end
     call_next(context)

--- a/src/pages/html_conversions/index_page.cr
+++ b/src/pages/html_conversions/index_page.cr
@@ -1,4 +1,4 @@
-class ConvertHtmlToLucky::IndexPage < PageLayout
+class HtmlConversions::NewPage < PageLayout
   needs input : String
   needs output : String
 
@@ -7,7 +7,7 @@ class ConvertHtmlToLucky::IndexPage < PageLayout
       h2 @title, class: "text-3xl mb-4"
       para "Lucky uses Crystal classes and methods to generate HTML. It may sound crazy at first, but the advantages are numerous. Never accidentally print nil to the page, extract and share partials using regular methods. Easily read an entire page by looking at just the render method. Text is automatically escaped for security. And it’s all type safe. That means no more unmatched closing tags, and never rendering a page with missing data."
 
-      form_for ConvertHtmlToLucky::Create, class: "my-4 space-y-2" do
+      form_for HtmlConversions::Create, class: "my-4 space-y-2" do
         div class: "space-y-1" do
           h3 "HTML Input", class: "text-2xl"
           textarea @input, name: "input", class: "appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 leading-tight focus:outline-none focus:bg-white", placeholder: "Paste your HTML here", attrs: [:required], rows: 4


### PR DESCRIPTION
I think it'd be nice to have a shorter URL that people can easily remember and type in.

This also make the namespace a REST resource and changes the folder name to match it