### PR TITLE
Add documentation section around generating models with columns

### DIFF
--- a/src/actions/guides/database/models.cr
+++ b/src/actions/guides/database/models.cr
@@ -38,6 +38,10 @@ class Guides::Database::Models < GuideAction
     * [User query](#{Guides::Database::Querying.path}) - Located in `./src/queries/user_query.cr`
     * [User migration](#{Guides::Database::Migrations.path}) - Location in `./db/migrations/#{Time.utc.to_s("%Y%m%d%H%I%S")}_create_users.cr`
 
+    You can even supply the model generator with typed columns, and Lucky will take care of adding those to the appropriate templates, too:
+
+    `lucky gen.model User name:String email:String age:Int32 admin:Bool`
+
     #{permalink(ANCHOR_SETTING_UP_A_MODEL)}
     ## Setting up a model
 


### PR DESCRIPTION
There's actually no way to know that you can provide column names to `lucky gen.model` in the website documentation, and you'd need to run `lucky gen.model --help` to figure it out!

Coming from Rails, I thought it'd be nice in that initial "Generating a Model" section to at least show something that would pop up in search results.

Not sure if y'all would prefer the positioning further up in the section or not, I kind of thought of this as a footnote to the section.