### PR TITLE
Replace old "render" calls with "html"

### DIFF
--- a/src/actions/guides/http_and_routing/routing_and_params.cr
+++ b/src/actions/guides/http_and_routing/routing_and_params.cr
@@ -237,7 +237,7 @@ class Guides::HttpAndRouting::RoutingAndParams < GuideAction
     class Frontend::Index < BrowserAction
       fallback do
         if html?
-          render Home::IndexPage
+          html Home::IndexPage
         else
           raise Lucky::RouteNotFoundError.new(context)
         end
@@ -296,7 +296,7 @@ class Guides::HttpAndRouting::RoutingAndParams < GuideAction
       get "/report" do
         small_number = calculate_numbers
         big_number = calculate_numbers + 1000
-        render ShowPage, small_number: small_number, big_number: big_number
+        html ShowPage, small_number: small_number, big_number: big_number
       end
 
       memoize def calculate_numbers : Int64


### PR DESCRIPTION
Closes https://github.com/luckyframework/lucky/issues/1233!

Searched for all occurrences of render using regex: `rg "render\s[A-Z]{1}"`, and this looks like the last two!