### PR TITLE
Clarify add_belongs_to default column and constraint

### DIFF
--- a/src/actions/guides/database/migrations.cr
+++ b/src/actions/guides/database/migrations.cr
@@ -405,7 +405,8 @@ class Guides::Database::Migrations < GuideAction
     This will generate a column called `author_id` on the `comments` table with a foreign key constraint pointing to an entry in the `users` table. It will also ensure that when a `User` is removed from the database, all associated `Comments` are also removed:
 
     ```
-    "comments_author_id_fkey" FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE CASCADE
+    comments_author_id_fkey" FOREIGN KEY (author_id) 
+        REFERENCES users(id) ON DELETE CASCADE
     ```
 
     You must include the `on_delete` option which can be one of

--- a/src/actions/guides/database/migrations.cr
+++ b/src/actions/guides/database/migrations.cr
@@ -387,6 +387,8 @@ class Guides::Database::Migrations < GuideAction
 
     The `add_belongs_to` method will create that foreign key constraint.
 
+    For example, we can tell our database that a `Comment` should reference a `User` as its author:
+
     ```crystal
     def migrate
       create table_for(Comment) do
@@ -398,6 +400,12 @@ class Guides::Database::Migrations < GuideAction
         add_belongs_to author : User, on_delete: :cascade
       end
     end
+    ```
+
+    This will generate a column called `author_id` on the `comments` table with a foreign key constraint pointing to an entry in the `users` table. It will also ensure that when a `User` is removed from the database, all associated `Comments` are also removed:
+
+    ```
+    "comments_author_id_fkey" FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE CASCADE
     ```
 
     You must include the `on_delete` option which can be one of


### PR DESCRIPTION
Did my best to close #205 

The only thing I'm not crazy about is the horizontal overflow on the code, but I think that showing the actual constraint Postgres output is both helpful, and consistent with how other items like `select_average` are documented. Here's a screenshot of the new section with the updated language:
![Screen Shot 2020-08-08 at 3 44 04 PM](https://user-images.githubusercontent.com/6677875/89718641-33735000-d98e-11ea-9fde-114e1601db17.png)
