### PR TITLE
Add compression documentation

### DIFF
--- a/src/actions/guides/frontend/asset-handling.cr
+++ b/src/actions/guides/frontend/asset-handling.cr
@@ -141,6 +141,21 @@ class Guides::Frontend::AssetHandling < GuideAction
 
     Make sure to use the `asset` macro to get fingerprinted assets.
 
+    ## Asset compression
+
+    Lucky supports static asset compression out of the box with a convenient middleware handler, `Lucky::StaticCompressionHandler`. You can add to the set of [default middleware handlers](#{Guides::HttpAndRouting::HTTPHandlers.path(anchor: Guides::HttpAndRouting::HTTPHandlers::ANCHOR_BUILT_IN_HANDLERS)}) as necessary in `src/app_server.cr`:
+
+    ```crystal
+    [
+      # ...
+      Lucky::StaticCompressionHandler.new("./public", file_ext: "br", content_encoding: "br"),
+      Lucky::StaticCompressionHandler.new("./public", file_ext: "gz", content_encoding: "gzip"),
+      # ...
+    ]
+    ```
+
+    Multiple instances of the `StaticCompressionHandler` can be leveraged to permit different types of compression based on browser support. For example, the settings above would serve Brotli-compressed assets for browsers that support it, and gzipped assets for those that don't.
+
     ## Asset host
 
     Once your app is in production, you may want to serve up your assets through a

--- a/src/actions/guides/http_and_routing/http_handlers.cr
+++ b/src/actions/guides/http_and_routing/http_handlers.cr
@@ -1,4 +1,5 @@
 class Guides::HttpAndRouting::HTTPHandlers < GuideAction
+  ANCHOR_BUILT_IN_HANDLERS = "perma-built-in-handlers"
   guide_route "/http-and-routing/http-handlers"
 
   def self.title
@@ -12,6 +13,7 @@ class Guides::HttpAndRouting::HTTPHandlers < GuideAction
     Crystal comes with a module [HTTP::Handler](https://crystal-lang.org/api/HTTP/Handler.html), which is used as middleware for your HTTP Server stack.
     These are classes you create that include the `HTTP::Handler` module to process incoming requests and return responses.
 
+    #{permalink(ANCHOR_BUILT_IN_HANDLERS)}
     ## Built-in handlers
 
     Lucky comes with some built-in handlers that you can see in your `src/app_server.cr` file under the `middleware` method.
@@ -20,16 +22,18 @@ class Guides::HttpAndRouting::HTTPHandlers < GuideAction
     By default when you generate a full application, your middleware stack will look like this:
 
     ```crystal
-    def middleware
+    def middleware : Array(HTTP::Handler)
       [
         Lucky::ForceSSLHandler.new,
         Lucky::HttpMethodOverrideHandler.new,
         Lucky::LogHandler.new,
         Lucky::ErrorHandler.new(action: Errors::Show),
+        Lucky::RemoteIpHandler.new,
         Lucky::RouteHandler.new,
-        Lucky::StaticFileHandler.new("./public", false),
+        Lucky::StaticCompressionHandler.new("./public", file_ext: "gz", content_encoding: "gzip"),
+        Lucky::StaticFileHandler.new("./public", fallthrough: false, directory_listing: false),
         Lucky::RouteNotFoundHandler.new,
-      ]
+      ] of HTTP::Handler
     end
     ```
 

--- a/src/actions/guides/http_and_routing/request_and_response.cr
+++ b/src/actions/guides/http_and_routing/request_and_response.cr
@@ -169,6 +169,11 @@ class Guides::HttpAndRouting::RequestAndResponse < GuideAction
     end
     ```
 
+    Text responses are compressed automatically based on two `Lucky::Server.settings` entries. If alternate behavior is desired, these settings can be adjusted in your Lucky app in `config/server.cr`
+
+    - `Lucky::Server.settings.gzip_enabled (default false)`
+    - `Lucky::Server.settings.gzip_content_types`
+
     #{permalink(ANCHOR_REDIRECTING)}
     ## Redirecting
 


### PR DESCRIPTION
This PR addresses a few things to close #223:

- Updated the default middleware documentation based on a newly-generated 0.23.0 Lucky app
- Added documentation surrounding the `Lucky::StaticCompressionHandler`
- Added documentation surrounding compression of `Lucky::TextResponse`