### PR TITLE
Add documentation for action request formats

### DIFF
--- a/src/actions/guides/http_and_routing/request_and_response.cr
+++ b/src/actions/guides/http_and_routing/request_and_response.cr
@@ -39,6 +39,40 @@ class Guides::HttpAndRouting::RequestAndResponse < GuideAction
     end
     ```
 
+    ### Setting accepted request formats
+
+    By default, generated Lucky apps set some helpful boundaries around what formats each action in your application can support.  These can be overriden in specific actions with the `accepted_formats` method.
+
+    For example, API actions only support JSON requests. Because only one format is specified as accepted, it is automatically set as the default format:
+
+    ```crystal
+    abstract class ApiAction < Lucky::Action
+      accepted_formats [:json]
+    end
+    ```
+
+    In an API action, requests would be handled like this:
+
+    - `https://myapp.com/api/users` with no specific request format => Server responds with JSON (the default format)
+    - `https://myapp.com/api/users` with `Accept: application/json` => Server responds with JSON (the requested, accepted format)
+    - `https://myapp.com/api/users` with `Accept: application/csv` => Server responds with 406 (not acceptable)
+
+    Browser actions, on the other hand, can support either JSON or HTML, and treat non-specified formats as HTML by default:
+
+    ```crystal
+    abstract class BrowserAction < Lucky::Action
+      accepted_formats [:html, :json], default: :html
+    end
+    ```
+
+    In a browser action, requests would be handled like this:
+
+    - `https://myapp.com/users` with no specific request format => Server responds with HTML (the default format)
+    - `https://myapp.com/users` with `Accept: application/json` => Server responds with JSON (the requested, accepted format)
+    - `https://myapp.com/users` with `Accept: application/csv` => Server responds with 406 (not acceptable)
+
+    It's important to note that this only controls which requests are *accepted* for processing, and does not automatically create or handle those responses appropriately. For example, requesting `https://myapp.com/users` with an `Accept: application/xml` header does not mean that valid XML content will be returned automatically, only that Lucky will allow your action to process the request.
+
     ## HTTP Headers
 
     ### Accessing Headers

--- a/src/actions/guides/http_and_routing/routing_and_params.cr
+++ b/src/actions/guides/http_and_routing/routing_and_params.cr
@@ -14,10 +14,10 @@ class Guides::HttpAndRouting::RoutingAndParams < GuideAction
     see how Lucky can make writing your applications reliable and productive
     with its unique approach to HTTP and routing.
 
-    ## Routing
+    ## Routing with Actions
 
     Instead of having separate definition files for routes and controllers, Lucky combines them in action classes.
-    This allows for solid error detection, and method and helper creation.
+    This allows for solid error detection, as well as method and helper creation.
 
     To save some typing, Lucky can automatically infer a default route path from the name of the action class,
     if the name ends with a known [RESTful action (see below)](##{ANCHOR_AUTOMATICALLY_GENERATE_RESTFUL_ROUTES}).


### PR DESCRIPTION
This PR aims to close #251.

The following items were addressed:

- Renamed overall "Request" header to include the phrase "Actions" to hopefully show up in search results for "Action"
- Added a new "Request Formats" section
- Added a section explaining how to accept and set default request formats
- Added a section explaining how to write an action to handle/support multiple request formats
- Opened https://github.com/luckyframework/lucky/pull/1234 to address some unclear doc blocks in the framework codebase