### PR TITLE
Remove "route" and "nested_route" code samples

### DIFF
--- a/src/actions/guides/authentication/browser_authentication.cr
+++ b/src/actions/guides/authentication/browser_authentication.cr
@@ -178,7 +178,7 @@ class Guides::Authentication::Browser < GuideAction
     class Posts::Index < BrowserAction
       include Auth::AllowGuests
 
-      route do
+      get "/posts" do
         html Posts::IndexPage, posts: PostQuery.new
       end
     end
@@ -204,7 +204,7 @@ class Guides::Authentication::Browser < GuideAction
 
     ```crystal
     class Settings::Edit < BrowserAction
-      route do
+      get "/settings/edit" do
         html Settings::EditPage
       end
     end

--- a/src/actions/guides/authentication/intro.cr
+++ b/src/actions/guides/authentication/intro.cr
@@ -49,7 +49,7 @@ class Guides::Authentication::Intro < GuideAction
       # This will allow users that are not signed in
       include Auth::AllowGuests
 
-      route do
+      get "/hello" do
         user = current_user
 
         # Check if user is signed in
@@ -74,7 +74,7 @@ class Guides::Authentication::Intro < GuideAction
 
     ```crystal
     class Articles::Create < BrowserAction
-      route do
+      post "/articles" do
         # Set 'author_id' to the current_user's id
         SaveArticle.create!(params, author_id: current_user.id) do |op, article|
           # ...
@@ -90,7 +90,7 @@ class Guides::Authentication::Intro < GuideAction
 
     ```crystal
     class MyArticles::Index < BrowserAction
-      route do
+      get "/articles" do
         # Filter articles by 'author_id'
         articles = ArticleQuery.new.author_id(current_user.id)
         html MyArticles::IndexPage, articles: articles

--- a/src/actions/guides/database/validating-saving.cr
+++ b/src/actions/guides/database/validating-saving.cr
@@ -164,7 +164,7 @@ class Guides::Database::ValidatingSaving < GuideAction
 
     ```crystal
     class Users::Create < BrowserAction
-      route do
+      post "/users" do
         # params will have the form params sent from the HTML form
         SaveUser.create(params) do |operation, user|
           if user # if the user was saved
@@ -429,8 +429,8 @@ class Guides::Database::ValidatingSaving < GuideAction
 
     ```crystal
     class Posts::Comments::Create < BrowserAction
-      route do
-        post = PostQuery.find(id)
+      post "/posts/:post_id/comments" do
+        post = PostQuery.find(post_id)
         # Params contain the title and body, but not the post_id
         # So we set it ourselves
         SaveComment.create(params, post_id: post.id) do |operation, comment|
@@ -602,7 +602,7 @@ class Guides::Database::ValidatingSaving < GuideAction
 
     ```crystal
     class Searches::Create < BrowserAction
-      route do
+      post "/searches" do
         SearchData.new(params).submit do |operation, results|
           # `valid?` is defined on `operation` for you!
           if operation.valid?

--- a/src/actions/guides/frontend/internationalization.cr
+++ b/src/actions/guides/frontend/internationalization.cr
@@ -482,7 +482,7 @@ class Guides::Frontend::Internationalization < GuideAction
     # src/actions/sign_ups/create.cr
     class SignUps::Create < BrowserAction
       # ...
-      route do
+      post "/sign_up" do
         SignUpUser.create(params) do |operation, user|
           if user
             flash.success = t("auth.sign_up_success")

--- a/src/actions/guides/frontend/rendering_html.cr
+++ b/src/actions/guides/frontend/rendering_html.cr
@@ -32,7 +32,7 @@ class Guides::Frontend::RenderingHtml < GuideAction
     ```crystal
     # in src/actions/users/index.cr
     class Users::Index < BrowserAction
-      route do
+      get "/users" do
         # Renders the Users::IndexPage
         html IndexPage, user_names: ["Paul", "Sally", "Jane"]
       end
@@ -709,7 +709,7 @@ class Guides::Frontend::RenderingHtml < GuideAction
     ```crystal
     # Without `expose`
     class Users::Index < BrowserAction
-      route do
+      get "/users" do
         html IndexPage, current_user_name: current_user_name
       end
 
@@ -722,7 +722,7 @@ class Guides::Frontend::RenderingHtml < GuideAction
     class Users::Index < BrowserAction
       expose current_user_name
 
-      route do
+      get "/users" do
         html IndexPage
       end
 

--- a/src/actions/guides/http_and_routing/request_and_response.cr
+++ b/src/actions/guides/http_and_routing/request_and_response.cr
@@ -27,13 +27,13 @@ class Guides::HttpAndRouting::RequestAndResponse < GuideAction
 
     ```crystal
     class Users::Show < BrowserAction
-      route do
+      get "/me" do
         if json?
           # The client wants json, so let's return some json
           json(UserSerializer.new(current_user))
         else
           # Just render the page like normal
-          html Users::ShowPage
+          html Users::ShowPage, user: current_user
         end
       end
     end
@@ -47,7 +47,7 @@ class Guides::HttpAndRouting::RequestAndResponse < GuideAction
 
     ```crystal
     class Dashboard::Index < BrowserAction
-      route do
+      get "/dashboard" do
         remote_ip = request.headers["X-Forwarded-For"]?
 
         if remote_ip
@@ -67,7 +67,7 @@ class Guides::HttpAndRouting::RequestAndResponse < GuideAction
 
     ```crystal
     class Admin::Reports::Show < BrowserAction
-      route do
+      get "/admin/reports/:report_id" do
         response.headers["Cache-Control"] = "max-age=150"
         html ShowPage
       end
@@ -180,7 +180,7 @@ class Guides::HttpAndRouting::RequestAndResponse < GuideAction
 
     ```crystal
     class Users::Create < BrowserAction
-      route do
+      post "/users" do
         redirect to: Users::Index # Default status is 302
         redirect to: Users::Show.with(user_id: "user_id") # If the action needs params
         redirect to: "/somewhere_else" # Redirect using a string path

--- a/src/actions/guides/json_and_apis/rendering_json.cr
+++ b/src/actions/guides/json_and_apis/rendering_json.cr
@@ -20,7 +20,7 @@ class Guides::JsonAndApis::RenderingJson < GuideAction
     ```crystal
     # in src/actions/api/articles/show.cr
     class Api::Articles::Show < ApiAction
-      route do
+      get "/api/articles/:article_id" do
         json({title: "My Post"})
         # Add an optional status code
         json({title: "My Post"}, HTTP::Status::OK) # or use an integer like `200`
@@ -57,7 +57,7 @@ class Guides::JsonAndApis::RenderingJson < GuideAction
     ```crystal
     # In the action
     class Api::Articles::Show < ApiAction
-      route do
+      get "/api/articles/:article_id" do
         article = ArticleQuery.new.find(id)
         # Render the article
         json ArticleSerializer.new(article)
@@ -75,7 +75,7 @@ class Guides::JsonAndApis::RenderingJson < GuideAction
 
     ```crystal
     class Api::Articles::Index < ApiAction
-      route do
+      get "/api/articles" do
         articles = ArticleQuery.new
         json ArticleSerializer.for_collection(articles)
       end

--- a/src/actions/guides/json_and_apis/saving-to-the-database.cr
+++ b/src/actions/guides/json_and_apis/saving-to-the-database.cr
@@ -49,7 +49,7 @@ class Guides::JsonAndApis::SavingToTheDatabase < GuideAction
 
     ```crystal
     class Api::Articles::Create < ApiAction
-      route do
+      post "/api/articles" do
         article = SaveArticle.create!(params)
         head HTTP::Status::Created
       end


### PR DESCRIPTION
This PR aims to close #279 

In the future, it is planned to remove `route` and `nested_route` helpers for routes. The issue associated with this PR links to GitHub Discussions that dive into much greater detail.

To facilitate that, this PR does two things:

- Refactors all calls to `route` and `nested_route` to use explicit routing
- Refactors the HTTP and Routing section to not reference or note the availability of `route` or `nested_route` with the goal of pushing new users to adopt explicit routing as their default

**Edit**

This PR is being refocused on only removing the example code using `route` and `nested_route`, while still leaving the actual documentation around those methods intact.