### PR TITLE
Correct Gzip Documentation

### DIFF
--- a/src/actions/guides/http_and_routing/request_and_response.cr
+++ b/src/actions/guides/http_and_routing/request_and_response.cr
@@ -205,7 +205,7 @@ class Guides::HttpAndRouting::RequestAndResponse < GuideAction
 
     Text responses are compressed automatically based on two `Lucky::Server.settings` entries. If alternate behavior is desired, these settings can be adjusted in your Lucky app in `config/server.cr`
 
-    - `Lucky::Server.settings.gzip_enabled (enabled by default in generated Lucky apps)`
+    - `Lucky::Server.settings.gzip_enabled` (enabled in production by default, disabled in development and test. Can be changed in `config/server.cr`)
     - `Lucky::Server.settings.gzip_content_types`
 
     #{permalink(ANCHOR_REDIRECTING)}

--- a/src/actions/guides/http_and_routing/request_and_response.cr
+++ b/src/actions/guides/http_and_routing/request_and_response.cr
@@ -205,7 +205,7 @@ class Guides::HttpAndRouting::RequestAndResponse < GuideAction
 
     Text responses are compressed automatically based on two `Lucky::Server.settings` entries. If alternate behavior is desired, these settings can be adjusted in your Lucky app in `config/server.cr`
 
-    - `Lucky::Server.settings.gzip_enabled (default false)`
+    - `Lucky::Server.settings.gzip_enabled (enabled by default in generated Lucky apps)`
     - `Lucky::Server.settings.gzip_content_types`
 
     #{permalink(ANCHOR_REDIRECTING)}


### PR DESCRIPTION
This PR aims to resolve #397.

While the default for gzip_enabled is `false` in the framework, because every Lucky app comes with an override to `true` in `config/server.cr` we should treat that as the default to avoid confusion.