### PR TITLE
Add HTMLConverter access through public API

### DIFF
--- a/spec/requests/api/html_conversions/create_spec.cr
+++ b/spec/requests/api/html_conversions/create_spec.cr
@@ -1,0 +1,17 @@
+require "../../../spec_helper"
+
+describe Api::HtmlConversions::Create do
+  it "returns a 200 response with converted content" do
+    response = AppClient.exec(Api::HtmlConversions::Create.with(input: "<div>Test</div>"))
+
+    response.should send_json(200, content: "div \"Test\"\n")
+  end
+
+  it "returns a 503 (Service Unavailable) when HTML conversions are disabled" do
+    ENV["DISABLE_HTML_CONVERSION_API"] = "Shut it down!"
+
+    response = AppClient.exec(Api::HtmlConversions::Create.with(input: "<div>Test</div>"))
+
+    response.status_code.should eq(503)
+  end
+end

--- a/spec/setup/start_app_server.cr
+++ b/spec/setup/start_app_server.cr
@@ -1,0 +1,9 @@
+app_server = AppServer.new
+
+spawn do
+  app_server.listen
+end
+
+Spec.after_suite do
+  app_server.close
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -11,5 +11,6 @@ require "./support/**"
 require "./setup/**"
 
 include Carbon::Expectations
+include Lucky::RequestExpectations
 
 Habitat.raise_if_missing_settings!

--- a/spec/support/app_client.cr
+++ b/spec/support/app_client.cr
@@ -1,0 +1,6 @@
+class AppClient < Lucky::BaseHTTPClient
+  def initialize
+    super
+    headers("Content-Type": "application/json")
+  end
+end

--- a/src/actions/api/html_conversions/create.cr
+++ b/src/actions/api/html_conversions/create.cr
@@ -1,0 +1,19 @@
+class Api::HtmlConversions::Create < ApiAction
+  before halt_if_html_conversion_disabled
+
+  param input : String = ""
+
+  post "/api/html_conversions" do
+    output = HTML2Lucky::Converter.new(input).convert
+
+    json({content: output}, :ok)
+  end
+
+  private def halt_if_html_conversion_disabled
+    if ENV["DISABLE_HTML_CONVERSION_API"]?
+      head :service_unavailable
+    else
+      continue
+    end
+  end
+end

--- a/src/actions/api_action.cr
+++ b/src/actions/api_action.cr
@@ -1,3 +1,4 @@
 abstract class ApiAction < Lucky::Action
   # Include modules and add methods that are for all API requests
+  accepted_formats [:json]
 end


### PR DESCRIPTION
This PR aims to close #404 with an API that returns 200s, not 404s as the issue number may suggest.

A few key components:
- Added a good old-fashioned `accepted_formats[:json]` to `ApiAction` to bring that file up to date with default generated Lucky apps, so that we don't have to specify allowed formats for all API actions in the future.
- Added a new `POST` route at `/api/html_conversions` that takes in a string called `input`, and returns a JSON payload with one top-level key called `content`, containing the HTML `input` converted to crystal. This mimics the structure and functionality already established in the browser action at `/src/actions/html_conversions/{create,new}.cr`.

Because our `ApiAction` already didn't include `Api::Auth::RequireAuthToken`, there was no need to add a specific authentication skipping include.