### PR TITLE
optimized version of github actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,23 +28,30 @@ jobs:
         node-version: '12.x'
     - name: "Install yarn"
       run: npm install -g yarn
+
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+    - name: Set up Yarn cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn--${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn--
+
+    - name: Set up Crystal cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          lib
+          ~/.cache/crystal
+        key: ${{ runner.os }}-crystal-${{ hashFiles('**/shard.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-crystal-
+
     - name: Setup Lucky
       run: script/setup
-    - name: Cache Crystal
-      uses: actions/cache@v1
-      with:
-        path: ~/.cache/crystal
-        key: ${{ runner.os }}-crystal
-    - name: Cache node modules
-      uses: actions/cache@v1
-      env:
-        cache-name: cache-node-modules
-      with:
-        path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
+
     - name: Run tests
       run: crystal spec


### PR DESCRIPTION
optimized version of github actions CI
* cache is used for node
* shards are cached

in current version cache is used only for ~/.cache/crystal