### PR TITLE
Add missing `sudo` in Ubuntu documentation

### DIFF
--- a/src/actions/guides/deploying/ubuntu.cr
+++ b/src/actions/guides/deploying/ubuntu.cr
@@ -55,7 +55,7 @@ class Guides::Deploying::Ubuntu < GuideAction
 
     ```bash
     sudo mkdir /srv/<yourapp>
-    chown deploy:deploy /srv/<yourapp>
+    sudo chown deploy:deploy /srv/<yourapp>
     ```
 
     ## Create a PostgreSQL database


### PR DESCRIPTION
A `sudo` is missing to be able to `chown deploy:deploy` the app directory.