### PR TITLE
Escape text that contains a quote when converting HTML to Lucky

### DIFF
--- a/spec/converter_spec.cr
+++ b/spec/converter_spec.cr
@@ -265,6 +265,16 @@ describe HTML2Lucky::Converter do
       div "two"
       CODE
     end
+
+
+  it "escape text that includes quotes" do
+    input = "<div>Hello \"world\"</div>"
+    expected_output = <<-CODE
+    div "Hello \\"world\\""
+    CODE
+    output = HTML2Lucky::Converter.new(input).convert
+    output.should eq_html(expected_output.strip)
+  end
   end
 end
 

--- a/spec/converter_spec.cr
+++ b/spec/converter_spec.cr
@@ -266,8 +266,7 @@ describe HTML2Lucky::Converter do
       CODE
     end
 
-
-  it "escape text that includes quotes" do
+  it "escapes text that includes quotes" do
     input = "<div>Hello \"world\"</div>"
     expected_output = <<-CODE
     div "Hello \\"world\\""

--- a/spec/converter_spec.cr
+++ b/spec/converter_spec.cr
@@ -266,14 +266,14 @@ describe HTML2Lucky::Converter do
       CODE
     end
 
-  it "escapes text that includes quotes" do
-    input = "<div>Hello \"world\"</div>"
-    expected_output = <<-CODE
-    div "Hello \\"world\\""
-    CODE
-    output = HTML2Lucky::Converter.new(input).convert
-    output.should eq_html(expected_output.strip)
-  end
+    it "escapes text that includes quotes" do
+      input = "<div>Hello \"world\"</div>"
+      expected_output = <<-CODE
+      div "Hello \\"world\\""
+      CODE
+      output = HTML2Lucky::Converter.new(input).convert
+      output.should eq_html(expected_output.strip)
+    end
   end
 end
 

--- a/vendor/html2lucky/tags/tag.cr
+++ b/vendor/html2lucky/tags/tag.cr
@@ -77,6 +77,6 @@ abstract class HTML2Lucky::Tag
   end
 
   private def wrap_quotes(string : String) : String
-    QUOTE + string + QUOTE
+    QUOTE + string.gsub("\"", "\\\"") + QUOTE
   end
 end


### PR DESCRIPTION
When you submit HTML that contains quotes inside the text, the lucky code generated is not correct.
```html
<div>Hello "world"</div>
```
produces:
```crystal
div "Hello "world""
```

it should produce:
```crystal
div "Hello \"world\""
```

This PR fixes this problem