### PR TITLE
Fix Markdown Regex Formatting Issue

### DIFF
--- a/src/actions/guides/command_line_tasks/custom_tasks.cr
+++ b/src/actions/guides/command_line_tasks/custom_tasks.cr
@@ -153,7 +153,7 @@ class Guides::CommandLineTasks::CustomTasks < GuideAction
       positional_arg :column_types,
                      "The columns for this model in format: col:type",
                      to_end: true,
-                     format: /\\w+:\\w+/
+                     format: /^\\w+:\\w+$/
 
       def call
         # `model_name` will equal "User"


### PR DESCRIPTION
This PR aims to resolve #434

The issue is likely related to the markdown lib since the last `+` in `/\\w+:\\w+/`.

While we should probably open an issue there, I was able to resolve this and fix a side-effect of the same code by adding line begin/end anchors (`^` and `$`).

This prevents me from using this task as `lucky gen.model MyModel some_column:anotherl33th4ck3r`, which would pass for the non-achored regex.