### PR TITLE
Add detailed Carbon Adapter documentation

### DIFF
--- a/src/actions/guides/emails/sending-emails-with-carbon.cr
+++ b/src/actions/guides/emails/sending-emails-with-carbon.cr
@@ -7,10 +7,9 @@ class Guides::Emails::SendingEmailsWithCarbon < GuideAction
 
   def markdown : String
     <<-MD
-    ## Carbon Configuration File
+    ## Configuring Email
 
-    Lucky generates a default email configuration file in `config/email.cr`. In that file you
-    can add SendGrid keys and change adapters.
+    Lucky leverages the [Carbon](https://github.com/luckyframework/carbon) library for writing, sending, and testing emails. Carbon can be configured using the default file generated with a new Lucky application in `config/email.cr`. In that file you can add SendGrid keys and change adapters.
 
     ## Adapters
     
@@ -23,6 +22,7 @@ class Guides::Emails::SendingEmailsWithCarbon < GuideAction
     There are two ways to leverage the `DevAdapter`. The first is by telling the adapter to simply capture all Carbon output without printing or displaying the email content, which is the default:
 
     ```crystal
+    # config/email.cr
     BaseEmail.configure do |settings|
       settings.adapter = Carbon::DevAdapter.new
     end
@@ -31,6 +31,7 @@ class Guides::Emails::SendingEmailsWithCarbon < GuideAction
     If you want to see your email content printed to your development or test server logs, you can use the optional `print_emails` flag:
 
     ```crystal
+    # config/email.cr
     BaseEmail.configure do |settings|
       settings.adapter = Carbon::DevAdapter.new(print_emails: true)
     end
@@ -43,16 +44,11 @@ class Guides::Emails::SendingEmailsWithCarbon < GuideAction
     Initializing the `SendGridAdapter` is as simple as initializing the adapter with your SendGrid API key in `config/email.cr`:
 
     ```crystal
+    # config/email.cr
     BaseEmail.configure do |settings|
       settings.adapter = Carbon::SendGridAdapter.new(api_key: ENV["SEND_GRID_KEY"])
     end
     ```
-
-    ### AWS SES Adapter
-
-    The `AwsSesAdapter` by community member [keizo3](https://github.com/keizo3/carbon_aws_ses_adapter), once configured with your AWS credentials, will send all emails through the [AWS SES](https://aws.amazon.com/ses/) email service.
-
-    See [the GitHub repository](https://github.com/keizo3/carbon_aws_ses_adapter) for additional details.
 
     ## Sending and testing emails
 

--- a/src/actions/guides/emails/sending-emails-with-carbon.cr
+++ b/src/actions/guides/emails/sending-emails-with-carbon.cr
@@ -7,10 +7,52 @@ class Guides::Emails::SendingEmailsWithCarbon < GuideAction
 
   def markdown : String
     <<-MD
-    ## Configuring Carbon
+    ## Carbon Configuration File
 
-    Lucky generates default configuration in `config/email.cr`. In that file you
+    Lucky generates a default email configuration file in `config/email.cr`. In that file you
     can add SendGrid keys and change adapters.
+
+    ## Adapters
+    
+    Carbon supports a growing number of adapters thanks to contributions from the community.
+
+    ### Dev Adapter
+    
+    The `DevAdapter` ships with Carbon by default, and is useful for handling emails in a development or test environment. It can also be leveraged in production to effectively disable emails.
+
+    There are two ways to leverage the `DevAdapter`. The first is by telling the adapter to simply capture all Carbon output without printing or displaying the email content, which is the default:
+
+    ```crystal
+    BaseEmail.configure do |settings|
+      settings.adapter = Carbon::DevAdapter.new
+    end
+    ```
+
+    If you want to see your email content printed to your development or test server logs, you can use the optional `print_emails` flag:
+
+    ```crystal
+    BaseEmail.configure do |settings|
+      settings.adapter = Carbon::DevAdapter.new(print_emails: true)
+    end
+    ```
+
+    ### SendGrid Adapter
+
+    The `SendGridAdapter` ships with Carbon by default, and once configured will send all emails through the [SendGrid](https://sendgrid.com) email service.
+    
+    Initializing the `SendGridAdapter` is as simple as initializing the adapter with your SendGrid API key in `config/email.cr`:
+
+    ```crystal
+    BaseEmail.configure do |settings|
+      settings.adapter = Carbon::SendGridAdapter.new(api_key: ENV["SEND_GRID_KEY"])
+    end
+    ```
+
+    ### AWS SES Adapter
+
+    The `AwsSesAdapter` by community member [keizo3](https://github.com/keizo3/carbon_aws_ses_adapter), once configured with your AWS credentials, will send all emails through the [AWS SES](https://aws.amazon.com/ses/) email service.
+
+    See [the GitHub repository](https://github.com/keizo3/carbon_aws_ses_adapter) for additional details.
 
     ## Sending and testing emails
 


### PR DESCRIPTION
This PR aims to close #432.

It breaks out a separate "Adapters" section, explaining each currently-supported adapter in greater detail, as well as specific options for the DevAdapter like `print_email`.

Here's a capture of the new page layout/content:

![new_adapter_documentation](https://user-images.githubusercontent.com/6677875/94818667-5d645400-03cc-11eb-89c3-e7b2d819808e.png)
