### PR TITLE
Add Debugging Section to Testing Guides

### DIFF
--- a/src/actions/guides/testing/debugging_tests.cr
+++ b/src/actions/guides/testing/debugging_tests.cr
@@ -37,7 +37,7 @@ class Guides::Testing::DebuggingTests < GuideAction
     end
     ```
 
-    If we wanted to see what the state of the interface looks like after the `should_be_signed_in` step, all we need to do is insert a `take_screenshot` method call like so:
+    If we wanted to see what the state of the interface looks like after the `flow.should_be_signed_in` step, all we need to do is insert a `flow.take_screenshot` method call like so:
 
     ```crystal
     require "../spec_helper"
@@ -48,7 +48,10 @@ class Guides::Testing::DebuggingTests < GuideAction
 
         flow.sign_up "password"
         flow.should_be_signed_in
+
+        # Take a picture of the screen, then proceed
         flow.take_screenshot
+
         flow.sign_out
         flow.sign_in "wrong-password"
         flow.should_have_password_error

--- a/src/actions/guides/testing/debugging_tests.cr
+++ b/src/actions/guides/testing/debugging_tests.cr
@@ -37,7 +37,7 @@ class Guides::Testing::DebuggingTests < GuideAction
     end
     ```
 
-    If we wanted to see what the state of the interface looks like after the `should_be_signed_in` step, all we need to do is insert a `take_screenshot` method call like so:
+    If we wanted to see what the state of the interface looks like after the `flow.should_be_signed_in` step, all we need to do is insert a `flow.take_screenshot` method call like so:
 
     ```crystal
     require "../spec_helper"

--- a/src/actions/guides/testing/debugging_tests.cr
+++ b/src/actions/guides/testing/debugging_tests.cr
@@ -1,0 +1,72 @@
+class Guides::Testing::DebuggingTests < GuideAction
+  guide_route "/testing/debugging"
+
+  def self.title
+    "Debugging Tests"
+  end
+
+  def markdown : String
+    <<-MD
+    ## Introduction
+  
+    Determining why a given test is failing can sometimes be difficult. This guide serves as a jumping-off point for some tips and tricks that you can leverage to resolve these issues more quickly for your Lucky applications.
+
+    ## Lucky Flow
+
+    ### Taking Screenshots
+    
+    When you're running an integration spec that tests your application interface using Lucky Flow, sometimes getting a picture of what's going on at a certain point on the screen can be incredibly helpful when diagnosing a failing test.
+
+    Say that we have the following spec file:
+
+    ```crystal
+    require "../spec_helper"
+
+    describe "Authentication flow" do
+      it "works" do
+        flow = AuthenticationFlow.new("test@example.com")
+
+        flow.sign_up "password"
+        flow.should_be_signed_in
+        flow.sign_out
+        flow.sign_in "wrong-password"
+        flow.should_have_password_error
+        flow.sign_in "password"
+        flow.should_be_signed_in
+      end
+    end
+    ```
+
+    If we wanted to see what the state of the interface looks like after the `should_be_signed_in` step, all we need to do is insert a `take_screenshot` method call like so:
+
+    ```crystal
+    require "../spec_helper"
+
+    describe "Authentication flow" do
+      it "works" do
+        flow = AuthenticationFlow.new("test@example.com")
+
+        flow.sign_up "password"
+        flow.should_be_signed_in
+        flow.take_screenshot
+        flow.sign_out
+        flow.sign_in "wrong-password"
+        flow.should_have_password_error
+        flow.sign_in "password"
+        flow.should_be_signed_in
+      end
+    end
+    ```
+    
+    The next time this test file runs, a screenshot of the state of the interface at that point in time will be added to the default `./tmp/screenshots` folder. You can open that image in your viewer of choice, diagnose the problem, and get one step closer to a passing test!
+
+    If you'd like to output screenshots to a different location from LuckyFlow, you can easily modify the path defined by the `screenshot_directory` setting:
+
+    ```crystal
+    LuckyFlow.configure do
+      settings.screenshot_directory = "./tmp/my_custom_folder"
+    end
+    ```
+    MD
+  end
+end

--- a/src/components/shared/header.cr
+++ b/src/components/shared/header.cr
@@ -55,8 +55,8 @@ class Shared::Header < BaseComponent
   private def nav_links
     nav_link("Guides", Guides::GettingStarted::Installing.path)
     nav_link("Blog", Blog::Index.path)
-    nav_link("Chat", "https://discord.gg/HeqJUcb")
-    nav_link("GitHub", "https://github.com/luckyframework/lucky")
+    nav_link("Chat", "https://discord.gg/HeqJUcb", target: "_blank")
+    nav_link("GitHub", "https://github.com/luckyframework/lucky", target: "_blank")
   end
 
   private def docsearch_input
@@ -82,9 +82,10 @@ class Shared::Header < BaseComponent
     end
   end
 
-  private def nav_link(title, href, active : Bool = false)
+  private def nav_link(title, href, active : Bool = false, target : String = "_self")
     a title,
       href: href,
+      target: target,
       class: "uppercase block md:inline-block font-bold text-white tracking-wider no-underline md:mr-4 px-8 py-5 md:px-4 md:py-8 text-sm hover:bg-blue-darker hover:text-white"
   end
 end

--- a/src/components/shared/header.cr
+++ b/src/components/shared/header.cr
@@ -55,8 +55,8 @@ class Shared::Header < BaseComponent
   private def nav_links
     nav_link("Guides", Guides::GettingStarted::Installing.path)
     nav_link("Blog", Blog::Index.path)
-    nav_link("Chat", "https://discord.gg/HeqJUcb", target: "_blank")
-    nav_link("GitHub", "https://github.com/luckyframework/lucky", target: "_blank")
+    nav_link("Chat", "https://discord.gg/HeqJUcb")
+    nav_link("GitHub", "https://github.com/luckyframework/lucky")
   end
 
   private def docsearch_input
@@ -82,10 +82,9 @@ class Shared::Header < BaseComponent
     end
   end
 
-  private def nav_link(title, href, active : Bool = false, target : String = "_self")
+  private def nav_link(title, href, active : Bool = false)
     a title,
       href: href,
-      target: target,
       class: "uppercase block md:inline-block font-bold text-white tracking-wider no-underline md:mr-4 px-8 py-5 md:px-4 md:py-8 text-sm hover:bg-blue-darker hover:text-white"
   end
 end

--- a/src/models/guides_list.cr
+++ b/src/models/guides_list.cr
@@ -65,6 +65,7 @@ class GuidesList
         Guides::Testing::HtmlAndInteractivity,
         Guides::Testing::CreatingTestData,
         Guides::Testing::TestingActions,
+        Guides::Testing::DebuggingTests,
       ] of GuideAction.class),
     ]
   end


### PR DESCRIPTION
This PR aims primarily to close #431.
It also could technically close #199, though it doesn't incorporate any additional content from the comments of that issue.

This should serve as a framework we can easily expand as more folks encounter problems and issues are opened.

Here's what the page ended up looking like:
![debugging_tests](https://user-images.githubusercontent.com/6677875/94829512-973b5780-03d8-11eb-8887-d40689ffa6c4.png)