### PR TITLE
Fix small typo in installing.cr

### DIFF
--- a/src/actions/guides/getting-started/installing.cr
+++ b/src/actions/guides/getting-started/installing.cr
@@ -28,7 +28,7 @@ class Guides::GettingStarted::Installing < GuideAction
 
     ### 3. Configure SSL for Crystal
 
-    You'll need to add tell Crystal how to find OpenSSL by adding an `export`
+    You'll need to tell Crystal how to find OpenSSL by adding an `export`
     to your `~/.bash_profile` or `~/.zshrc`.
 
     > You can run `echo $SHELL` in your terminal if you're not sure whether you


### PR DESCRIPTION
Caught a small typo while reading docs, one of those where you rephrase a sentence but accidentally leave a piece of the old one.