### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: master
+    reviewers:
+      - stephendolan
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: master
+    versioning-strategy: increase
+    reviewers:
+      - stephendolan


### PR DESCRIPTION
Ensure that GitHub Action and Yarn dependencies are always up to date. This avoids large (often messy) bulk dependency updates by forcing smaller, incremental changes.

A Crystal shard version checker doesn't yet exist, but when it does we should add that here as well.

Note that I've set myself as a reviewer for all PRs. I've also left the "Max open" number of PRs to 5.