### PR TITLE
Linux requirements - Ubuntu section added. 

### DIFF
--- a/src/actions/guides/getting-started/installing.cr
+++ b/src/actions/guides/getting-started/installing.cr
@@ -52,10 +52,16 @@ class Guides::GettingStarted::Installing < GuideAction
 
     ## Linux requirements
 
-    ### Debian (Ubuntu should be similar)
+    ### Debian
 
     ```plain
     apt-get install libc6-dev libevent-dev libpcre2-dev libpng-dev libssl1.0-dev libyaml-dev zlib1g-dev
+    ```
+
+    ### Ubuntu
+
+    ```plain
+    apt-get install libc6-dev libevent-dev libpcre2-dev libpcre3-dev libpng-dev libssl1.0-dev libyaml-dev zlib1g-dev
     ```
 
     ### Fedora (28)


### PR DESCRIPTION
libpcre3-dev is needed on top of Debian requirements.

Closes #470 