### PR TITLE
Allow rendering raw HTML with Cmark

### DIFF
--- a/src/utils/custom_markdown_renderer.cr
+++ b/src/utils/custom_markdown_renderer.cr
@@ -28,7 +28,7 @@ class CustomMarkdownRenderer
   end
 
   def self.html(content)
-    options = Cmark::Option.flags(ValidateUTF8, Smart)
+    options = Cmark::Option.flags(ValidateUTF8, Smart, Unsafe)
     html = Cmark.gfm_to_html(content, options)
     HtmlAutolink.new(html).call
   end


### PR DESCRIPTION
Closes #504.

When we switched to CMark, we didn't realize that it would substitute raw HTML for a comment:
https://github.com/amauryt/cr-cmark-gfm/blob/master/src/cmark/renderers/html_renderer.cr#L182-L190

We leverage raw HTML to support permalinks on pages:
https://github.com/luckyframework/website/blob/master/src/actions/guide_action.cr#L22-L24

To get around that behavior, we pass the `Unsafe` option to the HTML renderer. Details in the API docs here:
https://amauryt.github.io/cr-cmark-gfm/Cmark/Option.html#Unsafe

I **did** verify that a `<script>` tag, for example, is still rendered within quotes and not executed, since it's in the list of filtered tags specified in the GFM spec:
https://github.github.com/gfm/#example-653