### PR TITLE
Added note for WSL users when installing a Process manager.

### DIFF
--- a/src/actions/guides/getting-started/installing.cr
+++ b/src/actions/guides/getting-started/installing.cr
@@ -214,6 +214,8 @@ class Guides::GettingStarted::Installing < GuideAction
     > You can modify the `Procfile.dev` to start other processes like running
     > background jobs.
 
+    > For WSL users on Windows, Overmind is not recommended due to [compatibility issues](https://github.com/DarthSim/overmind/issues/88).
+
     #{permalink(ANCHOR_POSTGRESQL)}
     ## Postgres database
 


### PR DESCRIPTION
Fixes #469

Looking at the linked issue, it didn't seem like there was any motivation to fix it, but more just change how it's configured. Since we call the `overmind` command internally in Lucky, we'd have to somehow detect WSL, and then change the call. Documenting this is probably the easier route. 