### PR TITLE
Make file upload guide correction, add deletion to sample code

### DIFF
--- a/src/actions/guides/handling_files/file_uploads.cr
+++ b/src/actions/guides/handling_files/file_uploads.cr
@@ -65,7 +65,6 @@ class Guides::HandlingFiles::FileUploads < GuideAction
         if (old_profile_picture = profile_picture_path.value)
           delete_old_profile_picture(old_profile_picture)
         end
-    
         profile_picture_path.value = result.id
       end
     

--- a/src/actions/guides/handling_files/file_uploads.cr
+++ b/src/actions/guides/handling_files/file_uploads.cr
@@ -58,7 +58,6 @@ class Guides::HandlingFiles::FileUploads < GuideAction
 
       private def upload_pic(pic)
         result = Shrine.upload(File.new(pic.tempfile.path), "store", metadata: { "filename" => pic.filename })
-    
         # If the new file is uploaded, no reason to keep the old one!
         # If multiple models can share an image, run a query before deleting
         # to ensure you're not breaking any references.

--- a/src/actions/guides/handling_files/file_uploads.cr
+++ b/src/actions/guides/handling_files/file_uploads.cr
@@ -57,8 +57,20 @@ class Guides::HandlingFiles::FileUploads < GuideAction
       end
 
       private def upload_pic(pic)
-        result = Shrine.upload(File.read(pic.tempfile.path), "store", metadata: { "filename" => pic.filename })
+        result = Shrine.upload(File.new(pic.tempfile.path), "store", metadata: { "filename" => pic.filename })
+    
+        # If the new file is uploaded, no reason to keep the old one!
+        # If multiple models can share an image, run a query before deleting
+        # to ensure you're not breaking any references.
+        if (old_profile_picture = profile_picture_path.value)
+          delete_old_profile_picture(old_profile_picture)
+        end
+    
         profile_picture_path.value = result.id
+      end
+    
+      private def delete_old_profile_picture(image_id)
+        Shrine::UploadedFile.new(id: image_id, storage_key: "store").delete
       end
     end
     ```

--- a/src/actions/guides/handling_files/file_uploads.cr
+++ b/src/actions/guides/handling_files/file_uploads.cr
@@ -67,7 +67,6 @@ class Guides::HandlingFiles::FileUploads < GuideAction
         end
         profile_picture_path.value = result.id
       end
-    
       private def delete_old_profile_picture(image_id)
         Shrine::UploadedFile.new(id: image_id, storage_key: "store").delete
       end


### PR DESCRIPTION
There was an issue where `File.read` returns a `String`, but `Shrine.upload` requires an `IO` input. `File.new` works in an app I built as recently as today from the master branch of the shard.

Additionally, I realized that the code as-is would leave old images around, which isn't much of a problem with disk storage but can become super tricky if you're using AWS like I am.