### PR TITLE
Fix Shrine FileStorage sample to work

### DIFF
--- a/src/actions/guides/handling_files/file_uploads.cr
+++ b/src/actions/guides/handling_files/file_uploads.cr
@@ -38,8 +38,8 @@ class Guides::HandlingFiles::FileUploads < GuideAction
     ```crystal
     # config/shrine.cr
     Shrine.configure do |config|
-      config.storages["cache"] = Storage::FileSystem.new("uploads", prefix: "cache")
-      config.storages["store"] = Storage::FileSystem.new("uploads")
+      config.storages["cache"] = Shrine::Storage::FileSystem.new("uploads", prefix: "cache")
+      config.storages["store"] = Shrine::Storage::FileSystem.new("uploads")
     end
     ```
 


### PR DESCRIPTION
Didn't catch this earlier since I wasn't using the FileSystem option, but realized that it needs to be namespaced with `Shrine::` to actually find the `Storage::FileSystem` class from within a Lucky app's `config/shrine.cr` file.