### PR TITLE
More apparent after_save/after_commit skip behavior

### DIFF
--- a/src/actions/guides/database/validating-saving.cr
+++ b/src/actions/guides/database/validating-saving.cr
@@ -309,8 +309,8 @@ class Guides::Database::ValidatingSaving < GuideAction
     ### Callbacks for running before and after save
 
     * `before_save` - Ran before the record is saved.
-    * `after_save` - Ran after the record is saved.
-    * `after_commit` - Ran after `after_save`, and the database transaction has committed.
+    * `after_save` - Ran after the record is saved. Skipped if no changes are comitted to the database.
+    * `after_commit` - Ran after `after_save`, and the database transaction has committed. Skipped if no changes are committed to the database.
     * `after_completed` - Ran after all code has completed, and the save operation was successful.
 
     Create a method you'd like to run and then pass the method name to the


### PR DESCRIPTION
This line is a bit further down in the documentation but didn't stick out to me and I spent a bit of time debugging thinking I was doing something wrong:
> When updating a record, if there are no changes to be committed to the database, the after_save and after_commit callbacks are never run.

Hopefully, this will make it more apparent at a glance that `after_save` and `after_commit` only run if there are changes being committed to the database.

Maybe this is a bit redundant, so I'm happy to tweak the language if anyone has suggestions.