### PR TITLE
Import only the highlight.js core.

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -9,7 +9,7 @@ import Turbolinks from "turbolinks";
 RailsUjs.start();
 Turbolinks.start();
 
-import hljs from 'highlight.js';
+import hljs from 'highlight.js/lib/core';
 
 import javascript from 'highlight.js/lib/languages/javascript';
 hljs.registerLanguage('javascript', javascript);


### PR DESCRIPTION
The entire highlight.js was being imported, so the lines below importing the individual langs were unnecessary. 

With this change it only imports the core and the languages you have imported below it rather than all of the langs supported by the library, which seems like was the intention. 