### PR TITLE
Removing route and nested_route from guides.

### DIFF
--- a/src/actions/blog/index.cr
+++ b/src/actions/blog/index.cr
@@ -1,5 +1,5 @@
 class Blog::Index < BrowserAction
-  route do
+  get "/blog" do
     html IndexPage, title: "Blog", posts: PostQuery.new.all
   end
 end


### PR DESCRIPTION
Fixes #398

I replaced the guide with just info on using RESTful routes, and how the naming convention works.