### PR TITLE
Outdated lucky buildpack in deployment section of the documentation

### DIFF
--- a/src/actions/guides/deploying/heroku.cr
+++ b/src/actions/guides/deploying/heroku.cr
@@ -35,7 +35,7 @@ class Guides::Deploying::Heroku < GuideAction
     heroku buildpacks:add https://github.com/heroku/heroku-buildpack-nodejs
 
     # Then add this for all Lucky apps
-    heroku buildpacks:add https://github.com/luckyframework/heroku-buildpack-crystal
+    heroku buildpacks:add https://github.com/luckyframework/heroku-buildpack-lucky
     ```
 
     Set `LUCKY_ENV` to `production`:
@@ -137,12 +137,12 @@ class Guides::Deploying::Heroku < GuideAction
     (yet).
     Fortunately for us,
     Lucky has
-    [such a buildpack](https://github.com/luckyframework/heroku-buildpack-crystal)!
+    [such a buildpack](https://github.com/luckyframework/heroku-buildpack-lucky)!
     We'll add it so Heroku can download
     and install the dependencies for Lucky:
 
     ```bash
-    heroku buildpacks:add https://github.com/luckyframework/heroku-buildpack-crystal
+    heroku buildpacks:add https://github.com/luckyframework/heroku-buildpack-lucky
     ```
 
     ## Adding environment variables


### PR DESCRIPTION
The buildpack referenced to contain the crystal buildpack fails on heroku, and after viewing the repo's issues, it seems to be deprecated.
Maybe change it to https://github.com/luckyframework/heroku-buildpack-lucky, which in that issue is referenced as the new one.

I also tested with the new buildpack, and that works perfectly