### PR TITLE
Add documentation for updating Avram log verbosity

### DIFF
--- a/src/actions/guides/database/querying.cr
+++ b/src/actions/guides/database/querying.cr
@@ -824,9 +824,9 @@ class Guides::Database::Querying < GuideAction
       .to_prepared_sql
     #=> "SELECT COLUMNS FROM users INNER JOIN posts ON users.id = posts.user_id WHERE posts.tags = '{"crystal", "lucky"}' LIMIT 10"
     ```
-    
+
     If you'd prefer to see every query that is being run in your server logs, you can configure Avram's log level like this:
-    
+
     ```crystal
     # This is often set in `config/database.cr`
     Avram::QueryLog.dexter.configure(:info)

--- a/src/actions/guides/database/querying.cr
+++ b/src/actions/guides/database/querying.cr
@@ -824,6 +824,13 @@ class Guides::Database::Querying < GuideAction
       .to_prepared_sql
     #=> "SELECT COLUMNS FROM users INNER JOIN posts ON users.id = posts.user_id WHERE posts.tags = '{"crystal", "lucky"}' LIMIT 10"
     ```
+    
+    If you'd prefer to see every query that is being run in your server logs, you can configure Avram's log level like this:
+    
+    ```crystal
+    # This is often set in `config/database.cr`
+    Avram::QueryLog.dexter.configure(:info)
+    ```
     MD
   end
 end


### PR DESCRIPTION
We have `to_prepared_sql` in the guides for how to debug a single query, but nothing for when you want to debug all queries running for a given page/action.

To help with that, I've added a blurb about how to set the `Avram::QueryLog` level to `:info`.