### PR TITLE
Fix typo in tutorial

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -85,7 +85,7 @@
   <priority>0.7</priority>
  </url>
  <url>
-  <loc>https://luckyframework.org/guides/tutorial/assocations</loc>
+  <loc>https://luckyframework.org/guides/tutorial/associations</loc>
   <lastmod>2021-05-12T08:35:58-07:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.7</priority>

--- a/src/actions/guides/frontend/internationalization.cr
+++ b/src/actions/guides/frontend/internationalization.cr
@@ -133,7 +133,7 @@ class Guides::Frontend::Internationalization < GuideAction
 
     ## Step 4 - Add 'lang' to users table
 
-    This setup will assocatiate a language key with each user this language key is used when displaying information.
+    This setup will associate a language key with each user this language key is used when displaying information.
 
     Generate a migration using:
 

--- a/src/actions/guides/tutorial/02_assocations.cr
+++ b/src/actions/guides/tutorial/02_assocations.cr
@@ -2,7 +2,7 @@ class Guides::Tutorial::Assocations < GuideAction
   guide_route "/tutorial/assocations"
 
   def self.title
-    "Assocating Models"
+    "Associating Models"
   end
 
   def markdown : String
@@ -26,7 +26,7 @@ class Guides::Tutorial::Assocations < GuideAction
 
     ### Writing a migration
 
-    In this file, you will see two methods; `migrate` and `rollback`. The `migrate` method is run when we move our migration forward. (e.g. creating a new table).
+    In this file, you will see two methods; `migrate` and `rollback`. The `migrate` method is run when we move our migration forward (e.g. creating a new table).
     The `rollback` method is used to write the opposite of what `migrate` does. So if `migrate` creates a new table, then `rollback` should drop that table. You
     would use this to undo the last ran migration allowing you to fix, or revert your database schema.
 

--- a/src/actions/guides/tutorial/02_assocations.cr
+++ b/src/actions/guides/tutorial/02_assocations.cr
@@ -1,5 +1,5 @@
-class Guides::Tutorial::Assocations < GuideAction
-  guide_route "/tutorial/assocations"
+class Guides::Tutorial::Associations < GuideAction
+  guide_route "/tutorial/associations"
 
   def self.title
     "Associating Models"

--- a/src/models/guides_list.cr
+++ b/src/models/guides_list.cr
@@ -11,7 +11,7 @@ class GuidesList
       GuideCategory.new("Beginners Tutorial", [
         Guides::Tutorial::Overview,
         Guides::Tutorial::NewResource,
-        Guides::Tutorial::Assocations,
+        Guides::Tutorial::Associations,
         Guides::Tutorial::Design,
         Guides::Tutorial::UsingComponents,
         Guides::Tutorial::OperationsFactories,


### PR DESCRIPTION
The same "Assocation" typo exists in the class name, filename and route, but I didn't want to mess with those for fear of breaking things.