### PR TITLE
Update guides to use LuckyEnv

### DIFF
--- a/src/actions/guides/database/database_setup.cr
+++ b/src/actions/guides/database/database_setup.cr
@@ -97,7 +97,7 @@ class Guides::Database::DatabaseSetup < GuideAction
     but will not raise an exception in production.
 
     ```crystal
-    settings.lazy_load_enabled = Lucky::Env.production?
+    settings.lazy_load_enabled = LuckyEnv.production?
     ```
 
     ### Apps not using Avram
@@ -121,7 +121,7 @@ class Guides::Database::DatabaseSetup < GuideAction
     ## Test Setup
 
     If you'd like to use separate credentials for your testing database, you can add
-    another conditional in `config/database.cr` that checks for `Lucky::Env.test?` and
+    another conditional in `config/database.cr` that checks for `LuckyEnv.test?` and
     sets the `setting.url` option to the appropriate value.
 
     ## Create and Drop database

--- a/src/actions/guides/frontend/asset-handling.cr
+++ b/src/actions/guides/frontend/asset-handling.cr
@@ -165,7 +165,7 @@ class Guides::Frontend::AssetHandling < GuideAction
     ```crystal
     # In config/server.cr
     Lucky::Server.configure do |settings|
-      if Lucky::Env.production?
+      if LuckyEnv.production?
         settings.asset_host = "https://mycdnhost.com"
       else
         # Serve up assets locally in development and test

--- a/src/actions/guides/getting-started/configuration.cr
+++ b/src/actions/guides/getting-started/configuration.cr
@@ -20,19 +20,23 @@ class Guides::GettingStarted::Configuration < GuideAction
 
     ## Get the current environment
 
-    `Lucky::Env.name` will return the currently running environment
+    `LuckyEnv.environment` will return the currently running environment
 
-    You can also conditionally check the environment with `Lucky::Env.test?`,
-    `Lucky::Env.development?`, or `Lucky::Env.production?`
+    You can also conditionally check the environment with `LuckyEnv.development?`,
+    `LuckyEnv.test?`, or `LuckyEnv.production?`
 
     ## Set the current environment
 
-    `LUCKY_ENV=environment_name` to set the environment. By default it is `development`
+    `LUCKY_ENV=environment_name` to set the environment. By default it is `development`.
 
     ## Add custom environment
 
     If you need a custom environment like `staging`, for example, you can add this option in `config/env.cr`.
-    This will give you the helper method `Lucky::Env.staging?` for use in your app.
+    This will give you the helper method `LuckyEnv.staging?` for use in your app.
+
+    ```
+    LuckyEnv.add_env :staging
+    ```
 
     ## Configuring Lucky
 

--- a/src/actions/guides/getting-started/configuration.cr
+++ b/src/actions/guides/getting-started/configuration.cr
@@ -34,7 +34,7 @@ class Guides::GettingStarted::Configuration < GuideAction
     If you need a custom environment like `staging`, for example, you can add this option in `config/env.cr`.
     This will give you the helper method `LuckyEnv.staging?` for use in your app.
 
-    ```
+    ```crystal
     LuckyEnv.add_env :staging
     ```
 

--- a/src/actions/guides/http_and_routing/security_headers.cr
+++ b/src/actions/guides/http_and_routing/security_headers.cr
@@ -69,7 +69,7 @@ class Guides::HttpAndRouting::SecurityHeaders < GuideAction
     # config/server.cr
 
     Lucky::ForceSSLHandler.configure do |settings|
-      settings.enabled = Lucky::Env.production?
+      settings.enabled = LuckyEnv.production?
       settings.strict_transport_security = {max_age: 1.year, include_subdomains: true}
     end
     ```


### PR DESCRIPTION
Updates the guides to make use of `LuckyEnv` instead of `Lucky::Env`. See https://github.com/luckyframework/lucky_cli/pull/655 for details.