### PR TITLE
Add top-level chat redirect to Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 ### Future guide goals
 
-* Add screencasts
-* *Versioned*. Look at old ones, or even look at what's on master
-* Link to relevant screencasts
-* Helpful or not button
-  * If not, direct to Discord to get help
-* Check code snippets in real projects. More confidence code samples work.
+- Add screencasts
+- _Versioned_. Look at old ones, or even look at what's on master
+- Link to relevant screencasts
+- Helpful or not button
+  - If not, direct to Discord to get help
+- Check code snippets in real projects. More confidence code samples work.
 
 ## Setting up the project
 
@@ -28,4 +28,4 @@ Guides are located in the `src/actions/guides`. You can edit the markdown in eac
 
 ### Learning Lucky
 
-Lucky uses the [Crystal](https://crystal-lang.org) programming language. You can learn about Lucky from the [Lucky Guides](http://luckyframework.org/guides). Get help on our [Discord](https://discord.gg/HeqJUcb) server.
+Lucky uses the [Crystal](https://crystal-lang.org) programming language. You can learn about Lucky from the [Lucky Guides](http://luckyframework.org/guides). Get help on our [Discord](https://luckyframework.org/chat) server.

--- a/src/actions/chat/index.cr
+++ b/src/actions/chat/index.cr
@@ -1,0 +1,5 @@
+class Chat::Index < BrowserAction
+  get "/chat" do
+    redirect to: "https://discord.gg/HeqJUcb"
+  end
+end

--- a/src/actions/guides/json_and_apis/rendering_json.cr
+++ b/src/actions/guides/json_and_apis/rendering_json.cr
@@ -11,7 +11,7 @@ class Guides::JsonAndApis::RenderingJson < GuideAction
     <<-MD
     > This guide covers the basics of implementing a JSON API. If you have any
     questions about how to use Lucky in more complex ways, hop on our
-    [chatroom](https://discord.gg/HeqJUcb). We'd be happy to help!
+    [chatroom](#{Chat::Index.path}). We'd be happy to help!
 
     ## Respond with JSON
 

--- a/src/actions/guides/tutorial/00_overview.cr
+++ b/src/actions/guides/tutorial/00_overview.cr
@@ -31,7 +31,7 @@ class Guides::Tutorial::Overview < GuideAction
     ### Assumptions
 
     Before we begin, a few assumptions will be made about you, and your skill level. If at any point you feel confused or lost,
-    or just need clarification, please [chat with us](#{Links.chat_url}) so we can clear things up. We love to help!
+    or just need clarification, please [chat with us](#{Chat::Index.path}) so we can clear things up. We love to help!
 
     We assume you have...
 

--- a/src/actions/guides/tutorial/07_beyond_basics.cr
+++ b/src/actions/guides/tutorial/07_beyond_basics.cr
@@ -180,7 +180,7 @@ class Guides::Tutorial::BeyondBasics < GuideAction
     you may have missed something the first time around! Maybe the second time will allow you to get
     a little more adventurous with your code.
 
-    As always, if you run in to any issues, please join us in the [Discord Chat](#{Links.chat_url})
+    As always, if you run in to any issues, please join us in the [Discord Chat](#{Chat::Index.path})
     and someone will be around more than willing to help you out.
 
     > If you find any issues in this tutorial, please [Open an issue](https://github.com/luckyframework/website/issues) on

--- a/src/components/shared/footer.cr
+++ b/src/components/shared/footer.cr
@@ -10,7 +10,7 @@ class Shared::Footer < BaseComponent
           div class: "flex flex-wrap md:flex-no-wrap justify-between items-center py-4 md:py-0 md:px-6" do
             footer_icon("https://github.com/luckyframework/lucky", asset("icons/github.svg"), "Github")
             footer_icon("https://twitter.com/luckyframework", asset("icons/twitter.svg"), "Twitter")
-            footer_icon("https://discord.gg/HeqJUcb", asset("icons/discord.svg"), "Discord")
+            footer_icon(Chat::Index.path, asset("icons/discord.svg"), "Discord")
           end
         end
       end

--- a/src/components/shared/header.cr
+++ b/src/components/shared/header.cr
@@ -56,7 +56,7 @@ class Shared::Header < BaseComponent
     nav_link("Guides", Guides::GettingStarted::Installing.path)
     nav_link("Learn", Learn::Index.path)
     nav_link("Blog", Blog::Index.path)
-    nav_link("Chat", "https://discord.gg/HeqJUcb", target: "_blank")
+    nav_link("Chat", Chat::Index.path, target: "_blank")
     nav_link("GitHub", "https://github.com/luckyframework/lucky", target: "_blank")
   end
 

--- a/src/models/links.cr
+++ b/src/models/links.cr
@@ -1,6 +1,0 @@
-# These are external URLs we use throughout the site
-module Links
-  def self.chat_url
-    Chat::Index.path
-  end
-end

--- a/src/models/links.cr
+++ b/src/models/links.cr
@@ -1,6 +1,6 @@
 # These are external URLs we use throughout the site
 module Links
   def self.chat_url
-    "https://discord.gg/HeqJUcb"
+    Chat::Index.path
   end
 end

--- a/src/posts/lucky_0.24.cr
+++ b/src/posts/lucky_0.24.cr
@@ -159,7 +159,7 @@ class Lucky024Release < BasePost
 
     Please give it a spin and help us find bugs so our next release is even more solid.
     If you find any issues, don't hesitate to [report the issue](https://github.com/luckyframework/lucky/issues).
-    If you're unsure, just hop on [Discord chat](https://discord.gg/HeqJUcb) so we can help you out.
+    If you're unsure, just hop on [Discord chat](#{Chat::Index.path}) so we can help you out.
 
     Thanks so much for the support!
 
@@ -168,7 +168,7 @@ class Lucky024Release < BasePost
     If you haven't already, give us a [star on github](https://github.com/luckyframework/lucky),
     and be sure to follow us on [Twitter](https://twitter.com/luckyframework/).
 
-    For questions, or just to chat, come say hi on [Discord](https://discord.gg/HeqJUcb).
+    For questions, or just to chat, come say hi on [Discord](#{Chat::Index.path}).
     MD
   end
 end

--- a/src/posts/lucky_0.25.cr
+++ b/src/posts/lucky_0.25.cr
@@ -350,7 +350,7 @@ class Lucky025Release < BasePost
 
     Please give it a spin and help us find bugs so our next release is even more solid.
     If you find any issues, don't hesitate to [report them](https://github.com/luckyframework/lucky/issues).
-    If you're unsure, just hop on [Discord chat](https://discord.gg/HeqJUcb) so we can help you out.
+    If you're unsure, just hop on [Discord chat](#{Chat::Index.path}) so we can help you out.
 
     Thanks so much for the support!
 
@@ -359,7 +359,7 @@ class Lucky025Release < BasePost
     If you haven't already, give us a [star on GitHub](https://github.com/luckyframework/lucky),
     and be sure to follow us on [Twitter](https://twitter.com/luckyframework/).
 
-    For questions, or just to chat, come say hi on [Discord](https://discord.gg/HeqJUcb).
+    For questions, or just to chat, come say hi on [Discord](#{Chat::Index.path}).
     MD
   end
 end

--- a/src/posts/lucky_0.26.cr
+++ b/src/posts/lucky_0.26.cr
@@ -238,7 +238,7 @@ class Lucky026Release < BasePost
     Build anything, and let us know your thoughts. What do you like, what would you like to see improved?
 
     If you find any issues, don't hesitate to [report them](https://github.com/luckyframework/lucky/issues).
-    If you're unsure, just hop on [Discord chat](https://discord.gg/HeqJUcb) so we can help you out.
+    If you're unsure, just hop on [Discord chat](#{Chat::Index.path}) so we can help you out.
 
     Thanks so much for the support!
 
@@ -249,7 +249,7 @@ class Lucky026Release < BasePost
 
     Learn more about Lucky with the all new [LuckyCasts](https://luckycasts.com/)!
 
-    For questions, or just to chat, come say hi on [Discord](https://discord.gg/HeqJUcb).
+    For questions, or just to chat, come say hi on [Discord](#{Chat::Index.path}).
     MD
   end
 end

--- a/src/posts/lucky_0.27.cr
+++ b/src/posts/lucky_0.27.cr
@@ -102,7 +102,7 @@ class Lucky027Release < BasePost
 
     Learn tips and tricks with [LuckyCasts](https://luckycasts.com/).
 
-    For questions, or just to chat, come say hi on [Discord](https://discord.gg/HeqJUcb).
+    For questions, or just to chat, come say hi on [Discord](#{Chat::Index.path}).
     MD
   end
 end


### PR DESCRIPTION
Fixes #680 by adding a convenience redirect to Discord.

This will allow us to throw https://luckyframework.org/chat everywhere that we currently have a Discord link, which will make things a bit more consistent and resilient to change.