### PR TITLE
Add shortcut for contributing to Lucky

### DIFF
--- a/src/actions/contribute/index.cr
+++ b/src/actions/contribute/index.cr
@@ -1,0 +1,9 @@
+class Contribute::Index < BrowserAction
+  get "/contribute" do
+    search_params = URI::Params.build do |form|
+      form.add "q", "is:open is:issue org:luckyframework archived:false label:\"good first issue\""
+    end
+
+    redirect to: "https://github.com/issues?#{search_params}"
+  end
+end


### PR DESCRIPTION
Adds an action that takes a user to the following GitHub search:

https://github.com/issues?q=is%3Aopen+is%3Aissue+org%3Aluckyframework+archived%3Afalse+label%3A%22good+first+issue%22

This will make it easier to give newcomers to contributing the following link as an answer to "Where do I get started"?
https://luckyframework.org/contribute