### PR TITLE
Document routing style

### DIFF
--- a/src/actions/guides/http_and_routing/routing_and_params.cr
+++ b/src/actions/guides/http_and_routing/routing_and_params.cr
@@ -247,6 +247,33 @@ class Guides::HttpAndRouting::RoutingAndParams < GuideAction
     end
     ```
 
+    ## Routing style
+
+    By default Lucky ensures that all routes adhere to the same style. All
+    route paths are expected to use underscores unless you opt-out or change
+    the style check. You can opt-out from style checking by including
+    `Lucky::SkipRouteStyleCheck` in your action.
+
+    ```crystal
+    # src/actions/users/show.cr
+    class Users::Show < BrowserAction
+      include Lucky::SkipRouteStyleCheck
+
+      get "/users/user-:some_user_id" do
+        plain_text "Requested user id: \#{some_user_id}"
+      end
+    end
+    ```
+
+    Or, skipping checking altogether by removing
+    `Lucky::EnforceUnderscoredRoute` from `src/actions/browser_action.cr`.
+
+
+    Similarly, a custom style check can be added by adding the
+    `enforce_route_style` macro in your action. Or, for all actions by adding
+    it to `src/actions/browser_action.cr`. See [Lucky::EnforceUnderscoredRoute](https://github.com/luckyframework/lucky/blob/master/src/lucky/enforce_underscored_route.cr)
+    for an example.
+
     ## Memoization
 
     As your application gets larger, you may need to write helper methods that run expensive

--- a/src/actions/guides/http_and_routing/routing_and_params.cr
+++ b/src/actions/guides/http_and_routing/routing_and_params.cr
@@ -256,11 +256,11 @@ class Guides::HttpAndRouting::RoutingAndParams < GuideAction
 
     ```crystal
     # src/actions/users/show.cr
-    class Users::Show < BrowserAction
+    class Guides::GettingStarted < BrowserAction
       include Lucky::SkipRouteStyleCheck
 
-      get "/users/user-:some_user_id" do
-        plain_text "Requested user id: \#{some_user_id}"
+      get "/guides/getting-started" do
+        plain_text "Get started"
       end
     end
     ```


### PR DESCRIPTION
Add documentation regarding [routing style checks](https://github.com/luckyframework/lucky/pull/1536/).

<img width="1424" alt="Screenshot 2021-07-14 at 21 41 59" src="https://user-images.githubusercontent.com/503025/125683110-f5b1f432-ff03-457c-bef1-512e5a6f7a36.png">

Closes #703.

