### PR TITLE
Fix TailwindCSS deprecation

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,7 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        "light-blue": colors.lightBlue,
+        sky: colors.sky,
         rose: colors.rose,
 
         // Pre-2.0 colors for backwards compatibility


### PR DESCRIPTION
The color `lightBlue` have been renamed to `sky`.

```
assets       | warn - As of Tailwind CSS v2.2, `lightBlue` has been renamed to `sky`.
assets       | warn - Please update your color palette to eliminate this warning.
```