### PR TITLE
Add guide section for conditional HTTP Handlers

### DIFF
--- a/src/actions/guides/http_and_routing/http_handlers.cr
+++ b/src/actions/guides/http_and_routing/http_handlers.cr
@@ -87,7 +87,7 @@ class Guides::HttpAndRouting::HTTPHandlers < GuideAction
         #
         # To make sure that `middleware` still returns only `HTTP::Handler`s,
         # we `select(HTTP::Handler)` when returning from this method.
-        Lucky::Env.production? ? nil : Lucky::StaticFileHandler.new("./tmp", fallthrough: false, directory_listing: false),
+        LuckyEnv.production? ? nil : Lucky::StaticFileHandler.new("./tmp", fallthrough: false, directory_listing: false),
 
         Lucky::RouteNotFoundHandler.new,
       ].select(HTTP::Handler)

--- a/src/actions/guides/http_and_routing/http_handlers.cr
+++ b/src/actions/guides/http_and_routing/http_handlers.cr
@@ -63,6 +63,37 @@ class Guides::HttpAndRouting::HTTPHandlers < GuideAction
     end
     ```
 
+    ## Conditionally including handlers
+
+    There may be cases where you want a handler to be included only when certain conditions are met.
+    For example, let's say that we want to serve files from our `/tmp` directory in **development and test** environments, but not in production.
+    This can be accomplished with a ternary statement and slight restructure of the `middleware` method in `app_server.cr`:
+
+    ```crystal
+    def middleware : Array(HTTP::Handler)
+      [
+        Lucky::ForceSSLHandler.new,
+        Lucky::HttpMethodOverrideHandler.new,
+        Lucky::LogHandler.new,
+        Lucky::ErrorHandler.new(action: Errors::Show),
+        Lucky::RemoteIpHandler.new,
+        Lucky::RouteHandler.new,
+        Lucky::StaticCompressionHandler.new("./public", file_ext: "br", content_encoding: "br"),
+        Lucky::StaticCompressionHandler.new("./public", file_ext: "gz", content_encoding: "gzip"),
+        Lucky::StaticFileHandler.new("./public", fallthrough: false, directory_listing: false),
+
+        # Here is our new handler, which is `nil` when we're in production,
+        # and a `StaticFileHandler` when we're in other environments.
+        #
+        # To make sure that `middleware` still returns only `HTTP::Handler`s,
+        # we `select(HTTP::Handler)` when returning from this method.
+        Lucky::Env.production? ? nil : Lucky::StaticFileHandler.new("./tmp", fallthrough: false, directory_listing: false),
+
+        Lucky::RouteNotFoundHandler.new,
+      ].select(HTTP::Handler)
+    end
+    ```
+
     ## Creating custom handlers
 
     Your application may have special requirements like routing legacy URLs, sending bug reporting, CORS, or even doing [HTTP Basic auth](https://en.wikipedia.org/wiki/Basic_access_authentication) while your app is in beta.


### PR DESCRIPTION
I'm currently working on a file uploading LuckyCast where in development, we use local storage (`/tmp`). I didn't want to place files in `/public` because then we'd need to modify the `.gitignore`, and in my mind these files really *should* go into `/tmp` anyways.

To make this work, I needed Lucky to handle static files in `/tmp` just like `/public`, which meant I needed a new middleware handler like this:
`Lucky::StaticFileHandler.new("./tmp", fallthrough: false, directory_listing: false)`

It likely would have been fine to just add this to the middleware stack since production apps probably shouldn't have a `/tmp` directory being populated anyways, but ideally, this handler would *only* be leveraged in a production environment.

I had no idea how to do that and really struggled to get our currently `middleware` method to play nice without blowing it out to twice the number of lines. You can see my full journey in the Crystal Discord here:
https://discord.com/channels/591460182777790474/591597160492171264/866416692333903912

I wanted to document this kind of requirement on the website, but this is admittedly as much of a code review as a guide review 😄 . Is there a better way to do this? One concern that folks raised was that this could impact performance if this stack is evaluated once per request rather than at compile-time, which I'm still honestly not sure about.

Anyways, here's what the content looks like! I couldn't figure out a clean way to get rid of the scroll bar, but it gets the point across to start the discussion:
![CleanShot 2021-07-20 at 09 39 14](https://user-images.githubusercontent.com/6677875/126334898-93db9bfc-ca10-434e-86de-2c9b36e2b6fd.png)
