### PR TITLE
Make #raw text helper more searchable

### DIFF
--- a/src/actions/guides/frontend/rendering_html.cr
+++ b/src/actions/guides/frontend/rendering_html.cr
@@ -366,7 +366,7 @@ class Guides::Frontend::RenderingHtml < GuideAction
     end
     ```
 
-    ### Render unescaped text
+    ### Render unescaped (raw) text
 
     ```crystal
     div "email" do


### PR DESCRIPTION
Searching "raw" doesn't return the section that documents `raw`. I'm hoping that adding it in parentheses will help 😄 