### PR TITLE
adds documentation for int32 and float64 parameters on tasks

### DIFF
--- a/src/actions/guides/command_line_tasks/custom_tasks.cr
+++ b/src/actions/guides/command_line_tasks/custom_tasks.cr
@@ -134,6 +134,78 @@ class Guides::CommandLineTasks::CustomTasks < GuideAction
     # lucky search.reindex -m user
     ```
 
+    ### Int32 and Float64 args
+
+    Similar to the `switch` flags, we use `int32` and `float64` to define inputs that are numerical rather than `Bool` or `String`. Both of these options have a default of
+    zero (`0` or `0.0` respectively), which can be overridden with the `default` setting.  When the user omits an `int32` or `float64` input, the default is supplied as the input
+    to the task and this helps you gracefully avoid coding for `Nil` values.
+
+    #### Using the `int32` argument
+
+    `int32` macro defines `arg_name` where the return value is an `Int32`.
+    If the flag `--arg_name` is passed, the result is the value passed, otherwise is set to
+    the specified default, or `0` when not specified.
+    Crystal's numeric syntax is supported (i.e. `10_000`) when specifying default values.
+
+      * `arg_name` : String - The name of the argument
+      * `description` : String - The help text description for this option
+      * `shorcut` : String - An optional short flag (e.g. `-a`)
+      * `default` : Int32 - An optional default value (`0` is default when omittted)
+
+    ```crystal
+    class QueryOrders < LuckyTask::Task
+      summary "Example using int32 parameter."
+
+      # The second argument is the description of what this flag does.
+      int32 :limit, "limit (1000, 10_000, etc.)", shortcut: "-l", default: 1_000
+
+      def call
+        puts "Limiting number of orders returned to: %0d" % limit
+      end
+    end
+
+    # Run this task:
+    # lucky query_orders --limit=123
+    # => "Limiting number of orders returned to: 123"
+    #
+    # or with the shortcut option:
+    # lucky query_orders -l 456
+    # => "Limiting number of orders returned to: 456"
+    ```
+
+    #### Using the `float64` argument
+
+    `float64` macro defines `arg_name` where the return value is an `Float64`.
+    If the flag `--arg_name` is passed, the result is the value passed, otherwise is set to
+    the specified default, or `0.0` when not specified.
+    Crystal's numeric syntax is supported (i.e. `10_000`) when specifying default values.
+
+      * `arg_name` : String - The name of the argument
+      * `description` : String - The help text description for this option
+      * `shorcut` : String - An optional short flag (e.g. `-a`)
+      * `default` : Float64 - An optional default value (`0.0` is default when omittted)
+
+    ```crystal
+    class SmallOrders < LuckyTask::Task
+      summary "Example using float64 parameter."
+
+      # The second argument is the description of what this flag does.
+      float64 :max_amount, "specifies largest invoice amount", shortcut: "-x", default: 25.0
+
+      def call
+        puts "Finding orders up to and including %0.2f" % max_amount
+      end
+    end
+
+    # Run this task:
+    # lucky small_orders --max-amount=25.0
+    # => "Finding orders up to and including 25.0"
+    #
+    # or with the shortcut option:
+    # lucky query_orders -x 100
+    # => "Finding orders up to and including 100.0"
+    ```
+
     ### Positional args
 
     These are just syntactical sugar to allow you to pass values without needing to specify a flag. The built-in Lucky tasks use these type of args.


### PR DESCRIPTION
Provides documentation for the recently implemented `int32` and `float64` input macros on custom tasks that was merged on the `lucky_task` project here:  https://github.com/luckyframework/lucky_task/pull/3