### PR TITLE
Add note about truncate with cascade

### DIFF
--- a/src/actions/guides/database/deleting_records.cr
+++ b/src/actions/guides/database/deleting_records.cr
@@ -275,6 +275,17 @@ class Guides::Database::DeletingRecords < GuideAction
     UserQuery.truncate
     ```
 
+    > Running the `truncate` method may raise an error similar to the following:
+    >
+    > `Error message cannot truncate a table referenced in a foreign key constraint.`
+    >
+    > If that's the case, call the same method with the `cascade` option set to `true`:
+    >
+    > `UserQuery.truncate(cascade: true)`
+    >
+    > This will automatically delete or update matching records in a child table where a foreign key relationship is in place.
+
+
     ### Truncate database
 
     You can also truncate your entire database by calling `truncate` on your database class.

--- a/src/actions/guides/tutorial/02_assocations.cr
+++ b/src/actions/guides/tutorial/02_assocations.cr
@@ -90,7 +90,7 @@ class Guides::Tutorial::Associations < GuideAction
     puts "done!"
     ```
 
-    Once added, save and exit the file. This will tell Lucky to compile the code, and execute it, which will run a [`TRUNCATE`](/guides/database/deleting-records#truncate-table) on
+    Once added, save and exit the file. This will tell Lucky to compile the code, and execute it, which will run a [`TRUNCATE`](#{Guides::Database::DeletingRecords.path}) on
     the "fortunes" table. When it's complete, you'll see a message that tells you to hit `enter` to run more commands, or `q` to quit.
     We are done here, so type `q`, then hit enter to quit.
 

--- a/src/actions/guides/tutorial/02_assocations.cr
+++ b/src/actions/guides/tutorial/02_assocations.cr
@@ -85,12 +85,12 @@ class Guides::Tutorial::Associations < GuideAction
 
     puts "Truncating the Fortunes table"
 
-    FortuneQuery.truncate
+    FortuneQuery.truncate(cascade: true)
 
     puts "done!"
     ```
 
-    Once added, save and exit the file. This will tell Lucky to compile the code, and execute it, which will run a `TRUNCATE` on
+    Once added, save and exit the file. This will tell Lucky to compile the code, and execute it, which will run a [`TRUNCATE`](/guides/database/deleting-records#truncate-table) on
     the "fortunes" table. When it's complete, you'll see a message that tells you to hit `enter` to run more commands, or `q` to quit.
     We are done here, so type `q`, then hit enter to quit.
 


### PR DESCRIPTION
Adds more clarity about using the cascade option when truncating a table.

Also see: https://github.com/luckyframework/website/issues/859