### PR TITLE
New links and tagging system on Awesome list

### DIFF
--- a/src/components/awesome_link.cr
+++ b/src/components/awesome_link.cr
@@ -1,7 +1,7 @@
 class AwesomeLink < BaseComponent
   enum Tags
     Crypto
-    Adult # this link may contain content not suitable for persons under 18 years old
+    Adult # this link may contain content that is age restricted
   end
 
   needs text : String
@@ -33,9 +33,9 @@ class AwesomeLink < BaseComponent
   private def render_tags
     (tags || [] of Tags).each do |tag|
       if tag.adult?
-        span "18+",
+        span "Adult",
           class: "bg-red-500 text-white py-1 px-3 rounded text-xs ml-2",
-          title: "This link may contain content not suitable for persons under 18 years of age"
+          title: "This site may contain sensitive or age restricted content. Discretion is advised."
       else
         span tag.to_s,
           class: "bg-lucky-dark-green text-white py-1 px-3 rounded text-xs ml-2"

--- a/src/components/awesome_link.cr
+++ b/src/components/awesome_link.cr
@@ -1,14 +1,21 @@
 class AwesomeLink < BaseComponent
+  enum Tags
+    Crypto
+    Adult # this link may contain content not suitable for persons under 18 years old
+  end
+
   needs text : String
   needs url : String
   needs description : String?
+  needs tags : Array(Tags)?
 
   def render
     li do
-      a class: "block hover:bg-gray-50", href: url, target: "_blank" do
+      a class: "block hover:bg-gray-50", href: url, target: "_blank", data_confirm: confirmation_text do
         div class: "p-4 flex justify-between items-center" do
           section class: "truncate" do
             span text, class: "text-lucky-teal-blue text-lg font-medium"
+            render_tags
             if description
               para description.to_s, class: "text-gray-400 truncate"
             end
@@ -20,6 +27,27 @@ class AwesomeLink < BaseComponent
           end
         end
       end
+    end
+  end
+
+  private def render_tags
+    (tags || [] of Tags).each do |tag|
+      if tag.adult?
+        span "18+",
+          class: "bg-red-500 text-white py-1 px-3 rounded text-xs ml-2",
+          title: "This link may contain content not suitable for persons under 18 years of age"
+      else
+        span tag.to_s,
+          class: "bg-lucky-dark-green text-white py-1 px-3 rounded text-xs ml-2"
+      end
+    end
+  end
+
+  private def confirmation_text
+    if tags.try(&.includes?(Tags::Adult))
+      "Are you sure you want to visit #{text}? Discretion is advised"
+    else
+      ""
     end
   end
 end

--- a/src/pages/learn/awesome_lucky/index_page.cr
+++ b/src/pages/learn/awesome_lucky/index_page.cr
@@ -94,6 +94,16 @@ class Learn::AwesomeLucky::IndexPage < PageLayout
         text: "Scribe",
         url: "https://scribe.rip/",
         description: "Alternative frontend to Medium.com"
+      mount AwesomeLink,
+        text: "DendroRithms",
+        url: "https://dendrorithms.com/",
+        description: "DendroRithms is a generative art installation inspired by tree growth rings",
+        tags: [AwesomeLink::Tags::Crypto]
+      mount AwesomeLink,
+        text: "JoystickTV",
+        url: "https://joystick.tv/",
+        description: "Twitch-like live streaming platform for content creators with more freedom",
+        tags: [AwesomeLink::Tags::Adult]
     end
   end
 
@@ -200,6 +210,14 @@ class Learn::AwesomeLucky::IndexPage < PageLayout
         text: "Rosetta",
         url: "https://github.com/wout/rosetta",
         description: "A blazing fast internationalization library with compile-time key lookup"
+      mount AwesomeLink,
+        text: "Lucille",
+        url: "https://github.com/GrottoPress/lucille",
+        description: "Lucille is a collection of utilities for Lucky framework"
+      mount AwesomeLink,
+        text: "Bill",
+        url: "https://github.com/GrottoPress/bill",
+        description: "Bill is an Accounts Receivable automation system for Lucky framework"
     end
   end
 

--- a/src/pages/learn/awesome_lucky/index_page.cr
+++ b/src/pages/learn/awesome_lucky/index_page.cr
@@ -95,10 +95,13 @@ class Learn::AwesomeLucky::IndexPage < PageLayout
         url: "https://scribe.rip/",
         description: "Alternative frontend to Medium.com"
       mount AwesomeLink,
+        text: "Review My Email",
+        url: "https://reviewmy.email/",
+        description: "ReviewMy helps you submit quick snippets for review for emails, text messages, portions of larger documents"
+      mount AwesomeLink,
         text: "DendroRithms",
         url: "https://dendrorithms.com/",
-        description: "DendroRithms is a generative art installation inspired by tree growth rings",
-        tags: [AwesomeLink::Tags::Crypto]
+        description: "DendroRithms is a one-of-a-kind NFT generative art installation inspired by tree growth rings"
       mount AwesomeLink,
         text: "JoystickTV",
         url: "https://joystick.tv/",


### PR DESCRIPTION
Fixes #875

With the tagging system, we can now tag links as "Adult". This doesn't mean it's "porn", but more that the link *may* contain content not suitable for younger people. When clicking on a link tagged as "Adult", you get a confirmation before being taken to that URL.

Also note that we can add multiple tags to a single link.

<img width="578" alt="Screen Shot 2021-12-22 at 2 48 32 PM" src="https://user-images.githubusercontent.com/2391/147163811-58b18d3f-d8db-43aa-bf58-6a5a6cefd19a.png">

<img width="445" alt="Screen Shot 2021-12-22 at 2 48 38 PM" src="https://user-images.githubusercontent.com/2391/147163823-157530ad-fc37-4bf1-9ada-14c7e6e1123e.png">

