### PR TITLE
Add lucky cache card and docs

### DIFF
--- a/src/actions/guides/frontend/rendering_html.cr
+++ b/src/actions/guides/frontend/rendering_html.cr
@@ -966,10 +966,10 @@ class Guides::Frontend::RenderingHtml < GuideAction
     #{permalink(ANCHOR_RENDERING_TEMPLATES)}
     ## Caching HTML Content
 
-    Lucky applications can leverage [lucky_cache](https://github.com/luckyframework/lucky_cache) to cache HTML content within pages. By caching parts of your application, Lucky can serve already rendered and processed pages resulting in faster page loads for you application.
+    Lucky applications can leverage [lucky_cache](https://github.com/luckyframework/lucky_cache) to cache HTML content within pages. By caching parts of your application, Lucky can serve already rendered and processed pages resulting in faster page loads for your application.
 
     To begin utilizing `lucky_cache`, add it as a dependency to your `shards.yml` file.
-    ```
+    ```yaml
     dependencies:
       lucky_cache:
         github: luckyframework/lucky_cache
@@ -977,8 +977,10 @@ class Guides::Frontend::RenderingHtml < GuideAction
 
     Then run `shards install` to update your dependencies.
 
-    Next, you'll need to require `lucky_cache` in your application in `src/shards.cr`. Lastly, create a config file in `config/lucky_cache.cr` where you will configure the cache options.
-    ```
+    Next, you'll need to require `lucky_cache` in your application. Create a config file in `config/lucky_cache.cr` where you can configure the cache options.
+    ```crystal
+    # config/lucky_cache.cr
+
     require "lucky_cache"
 
     LuckyCache.configure do |settings|
@@ -990,7 +992,7 @@ class Guides::Frontend::RenderingHtml < GuideAction
     With `lucky_cache` now included in your Lucky application, you have access to the `LuckyCache::HtmlHelpers` module that can be included in your pages. This module exposes a `cache` method to be used to cache your HTML content.
 
     You'll need to provide a unique key to the `cache` method that Lucky can use to reference the unique content within the cache. A common pattern is to use any unique identifier, such as model id or page slug, to ensure no conflicts with cached data. The `cache` also provides an optional second argument that you can use to specify the duration until the cached data expired. If this argument is not provided, `lucky_cache` will default to the duration configured in the base application configuration.
-    ```
+    ```crystal
     class Posts::ShowPage < MainLayout
       include LuckyCache::HtmlHelpers
       needs post : Post

--- a/src/actions/guides/frontend/rendering_html.cr
+++ b/src/actions/guides/frontend/rendering_html.cr
@@ -975,7 +975,9 @@ class Guides::Frontend::RenderingHtml < GuideAction
         github: luckyframework/lucky_cache
     ```
 
-    Then run `shards install` to update your dependencies. Next, you'll need to add and configure `lucky_cache` in your application, such as in `src/app.cr`.
+    Then run `shards install` to update your dependencies.
+
+    Next, you'll need to require `lucky_cache` in your application in `src/shards.cr`. Lastly, create a config file in `config/lucky_cache.cr` where you will configure the cache options.
     ```
     require "lucky_cache"
 

--- a/src/actions/guides/frontend/rendering_html.cr
+++ b/src/actions/guides/frontend/rendering_html.cr
@@ -962,6 +962,48 @@ class Guides::Frontend::RenderingHtml < GuideAction
     ```erb
     My name is: <%= @user.name %>
     ```
+
+    #{permalink(ANCHOR_RENDERING_TEMPLATES)}
+    ## Caching HTML Content
+
+    Lucky applications can leverage [lucky_cache](https://github.com/luckyframework/lucky_cache) to cache HTML content within pages. By caching parts of your application, Lucky can serve already rendered and processed pages resulting in faster page loads for you application.
+
+    To begin utilizing `lucky_cache`, add it as a dependency to your `shards.yml` file.
+    ```
+    dependencies:
+      lucky_cache:
+        github: luckyframework/lucky_cache
+    ```
+
+    Then run `shards install` to update your dependencies. Next, you'll need to add and configure `lucky_cache` in your application, such as in `src/app.cr`.
+    ```
+    require "lucky_cache"
+
+    LuckyCache.configure do |settings|
+      settings.storage = LuckyCache::MemoryStore.new
+      settings.default_duration = 5.minutes
+    end
+    ```
+
+    With `lucky_cache` now included in your Lucky application, you have access to the `LuckyCache::HtmlHelpers` module that can be included in your pages. This module exposes a `cache` method to be used to cache your HTML content.
+
+    You'll need to provide a unique key to the `cache` method that Lucky can use to reference the unique content within the cache. A common pattern is to use any unique identifier, such as model id or page slug, to ensure no conflicts with cached data. The `cache` also provides an optional second argument that you can use to specify the duration until the cached data expired. If this argument is not provided, `lucky_cache` will default to the duration configured in the base application configuration.
+    ```
+    class Posts::ShowPage < MainLayout
+      include LuckyCache::HtmlHelpers
+      needs post : Post
+
+      def content
+        cache("post:\#{post.id}:comments", expires_in: 1.hour) do
+          post.comments.each do |comment|
+            div comment.text
+          end
+        end
+      end
+    end
+    ```
+
+    For more information about `lucky_cache`, see the [API docs](https://luckyframework.github.io/lucky_cache/).
     MD
   end
 end

--- a/src/pages/learn/ecosystem/index_page.cr
+++ b/src/pages/learn/ecosystem/index_page.cr
@@ -68,6 +68,10 @@ class Learn::Ecosystem::IndexPage < PageLayout
           name: "Lucky Env",
           description: "Environment variable parser.",
           slug: "lucky_env"
+        mount ProjectCard,
+          name: "Lucky Cache",
+          description: "Cache content within your Lucky application.",
+          slug: "lucky_cache"
       end
     end
   end


### PR DESCRIPTION
Adds guide for caching content with lucky_cache and adds lucky_cache to the ecosystem page. Closes #894 and closes #851

Screenshot of rendered guide
<img width="952" alt="Screen Shot 2022-01-11 at 7 42 26 PM" src="https://user-images.githubusercontent.com/13721476/149054525-b139a191-6dab-4175-83ae-cac0b53934a2.png">
