### PR TITLE
Add Dependabot Automerge Github action

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,14 @@
+name: Auto-merge minor/patch
+on:
+  schedule:
+    - cron: "0 * * * *"
+jobs:
+  test:
+    name: Auto-merge minor and patch updates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: koj-co/dependabot-pr-action@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          merge-minor: true
+          merge-patch: true

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -10,5 +10,5 @@ jobs:
       - uses: koj-co/dependabot-pr-action@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          merge-minor: true
+          merge-minor: false
           merge-patch: true


### PR DESCRIPTION
@jwoertink mentioned there aren't JS tests so this might not be the best move, but this merges minor/patch dependabot PRs automatically