### PR TITLE
Fixing deprecation warning

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -43,7 +43,7 @@ hljs.registerLanguage('diff', diff);
 
 document.addEventListener("turbolinks:load", function () {
   document.querySelectorAll('pre code').forEach((block) => {
-    hljs.highlightBlock(block);
+    hljs.highlightElement(block);
   });
 });
 


### PR DESCRIPTION
This `highlightBlock` function will be removed in v12. It was recommended to update it now.