### PR TITLE
Replacing turbolinks with turbo.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "private": true,
   "dependencies": {
     "@docsearch/js": "^3.0.0-alpha.50",
+    "@hotwired/turbo": "^7.1.0",
+    "@rails/ujs": "^7.0.2-2",
     "highlight.js": "^11.4.0",
-    "modern-normalize": "^1.1.0",
-    "rails-ujs": "^5.2.6",
-    "turbolinks": "^5.2.0"
+    "modern-normalize": "^1.1.0"
   },
   "scripts": {
     "heroku-postbuild": "yarn prod",

--- a/src/components/shared/layout_head.cr
+++ b/src/components/shared/layout_head.cr
@@ -5,8 +5,8 @@ class Shared::LayoutHead < BaseComponent
     head do
       utf8_charset
       title "Lucky - #{@seo.page_title}"
-      css_link asset("css/app.css"), data_turbolinks_track: "reload"
-      js_link asset("js/app.js"), defer: "defer", data_turbolinks_track: "reload"
+      css_link asset("css/app.css"), data_turbo_track: "reload"
+      js_link asset("js/app.js"), defer: "defer", data_turbo_track: "reload"
       csrf_meta_tags
       meta name: "description", content: @seo.page_description
       rss_link

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,13 +1,9 @@
 /* eslint no-console:0 */
 
 // RailsUjs is *required* for links in Lucky that use DELETE, POST and PUT.
-import RailsUjs from "rails-ujs";
+require("@rails/ujs").start();
+require("@hotwired/turbo");
 
-// Turbolinks is optional. Learn more: https://github.com/turbolinks/turbolinks/
-import Turbolinks from "turbolinks";
-
-RailsUjs.start();
-Turbolinks.start();
 
 import hljs from 'highlight.js/lib/core';
 
@@ -41,18 +37,17 @@ hljs.registerLanguage('yaml', yaml);
 import diff from 'highlight.js/lib/languages/diff';
 hljs.registerLanguage('diff', diff);
 
-document.addEventListener("turbolinks:load", function () {
+import docsearch from '@docsearch/js';
+
+document.addEventListener("turbo:load", function () {
   document.querySelectorAll('pre code').forEach((block) => {
     hljs.highlightElement(block);
   });
+
+  docsearch({
+    container: '#docsearch',
+    appId: 'P30IY9NAHF',
+    indexName: 'luckyframework',
+    apiKey: '5d744498cfdcf4d4340dc3751c5bfd5f',
+  });
 });
-
-import docsearch from '@docsearch/js';
-
-docsearch({
-  container: '#docsearch',
-  appId: 'P30IY9NAHF',
-  indexName: 'luckyframework',
-  apiKey: '5d744498cfdcf4d4340dc3751c5bfd5f',
-});
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -1058,6 +1058,11 @@
     "@docsearch/css" "3.0.0-alpha.50"
     algoliasearch "^4.0.0"
 
+"@hotwired/turbo@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.1.0.tgz#27e44e0e3dc5bd1d4bda0766d579cf5a14091cd7"
+  integrity sha512-Q8kGjqwPqER+CtpQudbH+3Zgs2X4zb6pBAlr6NsKTXadg45pAOvxI9i4QpuHbwSzR2+x87HUm+rot9F/Pe8rxA==
+
 "@jridgewell/resolve-uri@^3.0.3":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz#68eb521368db76d040a6315cdb24bf2483037b9c"
@@ -1096,6 +1101,11 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@rails/ujs@^7.0.2-2":
+  version "7.0.2-2"
+  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-7.0.2-2.tgz#9f2f114f4777627034be541151a1240ebe585199"
+  integrity sha512-2M+stexFdUwVXMo4sborFkGEI7A7qEl8iIZX9oqW/JOjEyl6jpjpKAtPCAvKrXQAduX8lBQKHj/eTQKqONVB0Q==
 
 "@trysound/sax@0.2.0":
   version "0.2.0"
@@ -4948,11 +4958,6 @@ quick-lru@^5.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
-rails-ujs@^5.2.6:
-  version "5.2.6"
-  resolved "https://registry.yarnpkg.com/rails-ujs/-/rails-ujs-5.2.6.tgz#4193242a108d0cd9ed3595695644755c0bd329eb"
-  integrity sha512-JpUq5RlA4p5XE69dz0ZOIkn1xXQn9H8VDXQJWuVPRtFBOFylWFriaDVpxFmdQuARPo4bm2l67uIMMBpX6KNY+g==
-
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -5822,11 +5827,6 @@ tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
   integrity sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=
-
-turbolinks@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/turbolinks/-/turbolinks-5.2.0.tgz#e6877a55ea5c1cb3bb225f0a4ae303d6d32ff77c"
-  integrity sha512-pMiez3tyBo6uRHFNNZoYMmrES/IaGgMhQQM+VFF36keryjb5ms0XkVpmKHkfW/4Vy96qiGW3K9bz0tF5sK9bBw==
 
 type-is@~1.6.18:
   version "1.6.18"


### PR DESCRIPTION
Fixes #917

I probably could have just moved the docsearch in to the turbolinks load block, but after seeing that turbolinks is officially archived, I decided to give turbo a shot. It was a pretty easy migration, and the search no longer disappears on us, so win win!