### PR TITLE
Remove Stephen Dolan from dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
     schedule:
       interval: "daily"
     target-branch: main
-    reviewers:
-      - stephendolan
 
   - package-ecosystem: npm
     directory: "/"
@@ -15,5 +13,3 @@ updates:
       interval: "daily"
     target-branch: main
     versioning-strategy: increase
-    reviewers:
-      - stephendolan


### PR DESCRIPTION
Now that we're auto-merging, I won't be monitoring these as closely.