### PR TITLE
Remove asdf recommendation

### DIFF
--- a/src/actions/guides/getting-started/installing.cr
+++ b/src/actions/guides/getting-started/installing.cr
@@ -19,9 +19,6 @@ class Guides::GettingStarted::Installing < GuideAction
 
     Lucky supports Crystal `>= #{LuckyCliVersion.min_compatible_crystal_version}`, `<= #{LuckyCliVersion.max_compatible_crystal_version}`
 
-    > We recommend using a version manager (like [asdf](https://crystal-lang.org/install/from_asdf/))
-    > to make sure the correct version of Crystal is used with Lucky.
-
     ### 1. Install Crystal
 
     Follow the [Installing Crystal](https://crystal-lang.org/install/) instructions page


### PR DESCRIPTION
Fixes #983

Using a version manager is nice, but installing with asdf has been causing a lot of SSL errors. It's better to just install Crystal the normal way so all of the dependencies are properly installed.