### PR TITLE
Update i18n instruction for Rosetta 0.7.0

### DIFF
--- a/src/actions/guides/frontend/internationalization.cr
+++ b/src/actions/guides/frontend/internationalization.cr
@@ -67,7 +67,7 @@ class Guides::Frontend::Internationalization < GuideAction
     bin/rosetta --init --lucky
     ```
 
-    This command will geneate:
+    This command will generate:
 
     **1. An initializer at `config/rosetta.cr` with the following content:**
 
@@ -82,7 +82,7 @@ class Guides::Frontend::Internationalization < GuideAction
 
     Rosetta has an integration macro for Lucky to include the
     `Rosetta::Translatable` module everywhere translations are needed. It also
-    adds the necessary method overloads to make Lucky seamlessly work with the
+    adds the necessary method overloads to make Lucky work seamlessly with the
     underlying `Rosetta::Translation` objects. Add the following line at the
     bottom of `config/rosetta.cr`, and you're good to go:
 
@@ -262,7 +262,7 @@ class Guides::Frontend::Internationalization < GuideAction
       # ...
       before_save do
         # ...
-        validate_inclusion_of language, in: Rosetta.available_locales.map(&.to_s)
+        validate_inclusion_of language, in: Rosetta.available_locales
         # ...
       end
     end
@@ -338,7 +338,7 @@ class Guides::Frontend::Internationalization < GuideAction
     > **Note 2**: when translating the link with `r("default.button.sign_out")`,
     > the `.t` method isn't called. That's because the returned value of the `r`
     > macro includes `Lucky::AllowedInTags`, so it's translated implicitly. This
-    > true almost everywhere, except for custom validation error messages in
+    > is true almost everywhere, except for custom validation error messages in
     > operations.
 
     Do the same for `AuthLayout`:

--- a/src/actions/guides/frontend/internationalization.cr
+++ b/src/actions/guides/frontend/internationalization.cr
@@ -163,6 +163,19 @@ class Guides::Frontend::Internationalization < GuideAction
           page_title: "Sign in"
     ```
 
+    ### Configure the i18n backend for Avram
+    Tell Avram to use Rosetta's backend to translate the default validation
+    error messages:
+
+    ```crystal
+    # config/database.cr
+    # ...
+    Avram.configure do |settings|
+      # ...
+      settings.i18n_backend = Rosetta::AvramBackend.new
+    end
+    ```
+
     ## Step 3 - Add language to the users table
 
     This setup will associate a language key with each user. Generate a

--- a/src/actions/guides/frontend/internationalization.cr
+++ b/src/actions/guides/frontend/internationalization.cr
@@ -83,12 +83,13 @@ class Guides::Frontend::Internationalization < GuideAction
     Rosetta has an integration macro for Lucky to include the
     `Rosetta::Translatable` module everywhere translations are needed. It also
     adds the necessary method overloads to make Lucky work seamlessly with the
-    underlying `Rosetta::Translation` objects. Add the following line at the
-    bottom of `config/rosetta.cr`, and you're good to go:
+    underlying `Rosetta::Translation` objects. Add the following line *before*
+    `Rosetta::Backend.load` in `config/rosetta.cr`, and you're good to go:
 
     ```crystal
     # ...
     Rosetta::Lucky.integrate
+    Rosetta::Backend.load("config/rosetta")
     ```
 
     **2. `config/rosetta/rosetta.en.yml`**


### PR DESCRIPTION
I've just released Rosetta v0.7.0 which includes a number of [improvements for Lucky](https://github.com/wout/rosetta/blob/main/src/rosetta/lucky/integration.cr). Integration is now better for:
- `Lucky::FlashStore`
- `Lucky::SpecialtyTags`
- `Lucky::FormHelpers`

It also adds a `Rosetta::AvramBackend` for validation translations, and there's a special [initializer flag for Lucky](https://wout.github.io/rosetta/v0.7.0/getting_started/#using-lucky).

Finally, the configuration API has changed a bit. Configuring the default locale, available locales and pluralization rules is now done using annotations instead of constants.

Also, in recent benchmarks, Rosetta is now 12 to 700 times faster than similar libraries. :nerd_face: 