### PR TITLE
Update installation instructions for M1 & Intel Macs

### DIFF
--- a/src/actions/guides/getting-started/installing.cr
+++ b/src/actions/guides/getting-started/installing.cr
@@ -173,16 +173,11 @@ class Guides::GettingStarted::Installing < GuideAction
     ### 6. Move the generated binary to your path
 
     This will let you use `lucky` from the command line.
-
-    macOS (Intel)
+    
     ```plain
     cp bin/lucky /usr/local/bin
     ```
-    
-    macOS (M1)
-    ```plain
-    cp bin/lucky /opt/homebrew/bin
-    ```
+    Or anywhere else you deem fit
 
     ### 7. Check installation
 

--- a/src/actions/guides/getting-started/installing.cr
+++ b/src/actions/guides/getting-started/installing.cr
@@ -173,7 +173,6 @@ class Guides::GettingStarted::Installing < GuideAction
     ### 6. Move the generated binary to your path
 
     This will let you use `lucky` from the command line.
-    
     ```plain
     cp bin/lucky /usr/local/bin
     ```

--- a/src/actions/guides/getting-started/installing.cr
+++ b/src/actions/guides/getting-started/installing.cr
@@ -67,15 +67,27 @@ class Guides::GettingStarted::Installing < GuideAction
       are using ZSH or Bash.
 
     **For ZSH (the default as of macOS Catalina):**
-
+    
+    MacOS (Intel)
     ```plain
     echo 'export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig' >>~/.zshrc
     ```
-
+    
+    Macos (M1)
+    ```plain
+    echo 'export PKG_CONFIG_PATH=/opt/homebrew/opt/openssl/lib/pkgconfig' >>~/.zshrc
+    ```
+    
     **For Bash:**
 
+    MacOS (Intel)
     ```plain
     echo 'export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig' >>~/.bash_profile
+    ```
+    
+    MacOs (M1)
+    ```plain
+    echo 'export PKG_CONFIG_PATH=/opt/homebrew/opt/openssl/lib/pkgconfig' >>~/.bash_profile
     ```
 
     > If you get an error like this: "Package libssl/libcrypto was not found in the
@@ -162,8 +174,14 @@ class Guides::GettingStarted::Installing < GuideAction
 
     This will let you use `lucky` from the command line.
 
+    MacOS (Intel)
     ```plain
     cp bin/lucky /usr/local/bin
+    ```
+    
+    MacOS (M1)
+    ```plain
+    cp bin/lucky /opt/homebrew/bin
     ```
 
     ### 7. Check installation

--- a/src/actions/guides/getting-started/installing.cr
+++ b/src/actions/guides/getting-started/installing.cr
@@ -68,24 +68,24 @@ class Guides::GettingStarted::Installing < GuideAction
 
     **For ZSH (the default as of macOS Catalina):**
     
-    MacOS (Intel)
+    macOS (Intel)
     ```plain
     echo 'export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig' >>~/.zshrc
     ```
     
-    Macos (M1)
+    macOS (M1)
     ```plain
     echo 'export PKG_CONFIG_PATH=/opt/homebrew/opt/openssl/lib/pkgconfig' >>~/.zshrc
     ```
     
     **For Bash:**
 
-    MacOS (Intel)
+    macOS (Intel)
     ```plain
     echo 'export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig' >>~/.bash_profile
     ```
     
-    MacOs (M1)
+    macOS (M1)
     ```plain
     echo 'export PKG_CONFIG_PATH=/opt/homebrew/opt/openssl/lib/pkgconfig' >>~/.bash_profile
     ```
@@ -174,12 +174,12 @@ class Guides::GettingStarted::Installing < GuideAction
 
     This will let you use `lucky` from the command line.
 
-    MacOS (Intel)
+    macOS (Intel)
     ```plain
     cp bin/lucky /usr/local/bin
     ```
     
-    MacOS (M1)
+    macOS (M1)
     ```plain
     cp bin/lucky /opt/homebrew/bin
     ```


### PR DESCRIPTION
By default the Homebrew directory is /opt/homebrew on M1 Macs & /usr/local for Intel Macs