### PR TITLE
Doc: mark postgres as optional (no more db dependency)

### DIFF
--- a/src/actions/guides/getting-started/installing.cr
+++ b/src/actions/guides/getting-started/installing.cr
@@ -177,7 +177,13 @@ class Guides::GettingStarted::Installing < GuideAction
     This should return `#{LuckyCliVersion.current_version}`
 
     #{permalink(ANCHOR_POSTGRESQL)}
-    ## Postgres database
+    ## Postgres database (optional)
+
+    > You can skip this if you don't need database. Many sites (including this one) have no need for a database. In some cases,
+    your data comes from a 3rd party API, or maybe you need a custom database engine other than PostgreSQL.
+    
+    > You can skip this if you plan to use Lucky with a Postgres docker container. NB: A docker-compose configuration (with Postgres included) 
+    is provided out of the box when you start your project with `lucky init`.
 
     ### 1. Install Postgres
 

--- a/src/actions/guides/getting-started/installing.cr
+++ b/src/actions/guides/getting-started/installing.cr
@@ -182,7 +182,7 @@ class Guides::GettingStarted::Installing < GuideAction
     > You can skip this if you don't need database. Many sites (including this one) have no need for a database. In some cases,
     your data comes from a 3rd party API, or maybe you need a custom database engine other than PostgreSQL.
 
-    > You can skip this if you plan to use Lucky with a Postgres docker container. NB: A docker-compose configuration (with Postgres included)
+    > You can skip this if you plan to use Lucky with a Postgres docker container. Please note that a docker-compose configuration (with Postgres included)
     is provided out of the box when you start your project with `lucky init`.
 
     ### 1. Install Postgres

--- a/src/actions/guides/getting-started/installing.cr
+++ b/src/actions/guides/getting-started/installing.cr
@@ -181,8 +181,8 @@ class Guides::GettingStarted::Installing < GuideAction
 
     > You can skip this if you don't need database. Many sites (including this one) have no need for a database. In some cases,
     your data comes from a 3rd party API, or maybe you need a custom database engine other than PostgreSQL.
-    
-    > You can skip this if you plan to use Lucky with a Postgres docker container. NB: A docker-compose configuration (with Postgres included) 
+
+    > You can skip this if you plan to use Lucky with a Postgres docker container. NB: A docker-compose configuration (with Postgres included)
     is provided out of the box when you start your project with `lucky init`.
 
     ### 1. Install Postgres

--- a/src/posts/lucky_1.0.0-rc1.cr
+++ b/src/posts/lucky_1.0.0-rc1.cr
@@ -38,7 +38,7 @@ class Lucky100rc1Release < BasePost
 
     ### No more DB dependency
 
-    Many sites (including this one) have no need for a databaase. In some cases,
+    Many sites (including this one) have no need for a database. In some cases,
     your data comes from a 3rd party API, or maybe you need a custom database
     engine other than PostgreSQL.
 


### PR DESCRIPTION
### What
* Mark Postgres as optional in the guide [Getting started > Installing](https://luckyframework.org/guides/getting-started/installing)
* Add some docker information
* Typo fix in the blog

### Why
Sync the documentation with 1.0RC1 release. No more db dependency :partying_face: 
https://luckyframework.org/blog/lucky-1_0_0-rc1-release

When I started lucky I followed this documentation and I was afraid of installing Postgres on my host.
So I started to do my own containers at that moment ... and only after I realized:
* docker compose are already created for me
* db is not mandatory in lucky

I think it is worth mentioning it in the doc because it could be a deal breaker for some people.

### Screenshot
Before
![image](https://user-images.githubusercontent.com/7020190/198866534-6d6dfb4c-baf4-433d-806c-6ae3b3097937.png)
After
![image](https://user-images.githubusercontent.com/7020190/199062480-e18586fa-e062-4d51-aae3-41610f017c2e.png)
