### PR TITLE
Fixing syntax error in the guides. 

### DIFF
--- a/src/actions/guides/testing/testing_actions.cr
+++ b/src/actions/guides/testing/testing_actions.cr
@@ -80,7 +80,7 @@ class Guides::Testing::TestingActions < GuideAction
 
       def page(page : Int32, per_page = 10)
         # Set pagination headers
-        headers("Range":  "order,id \#{page * per_page}; order=desc,max=\#{per_page}"
+        headers("Range":  "order,id \#{page * per_page}; order=desc,max=\#{per_page}")
       end
     end
     ```


### PR DESCRIPTION
Fixes #1137