### PR TITLE
Fix document

### DIFF
--- a/src/actions/guides/http_and_routing/flash.cr
+++ b/src/actions/guides/http_and_routing/flash.cr
@@ -27,9 +27,8 @@ class Guides::HttpAndRouting::Flash < GuideAction
     ```
 
     These will be rendered by the flash component in
-    `src/components/shared/flash_messages.cr`. The flash component is called from
-    your `MainLayout` and `AuthLayout` (found in `src/pages/`) by the
-    `render_flash` method.
+    `src/components/shared/flash_messages.cr`. The flash component was mounted from
+    your `MainLayout` and `AuthLayout` (found in `src/pages/`).
 
     You can modify the layout or the component to add HTML classes, change where
     flash is rendered, etc.

--- a/src/actions/guides/http_and_routing/link_generation.cr
+++ b/src/actions/guides/http_and_routing/link_generation.cr
@@ -59,7 +59,7 @@ class Guides::HttpAndRouting::LinkGeneration < GuideAction
     In a web page, an anchor is a an element you can use to take a user to a specific part of a page.
     For example, we use this to link to different parts of a guide page.
 
-    The `path` method takes an `anchor` argument.
+    The `with` method takes an `anchor` argument.
 
     ```crystal
     def content

--- a/src/actions/guides/http_and_routing/request_and_response.cr
+++ b/src/actions/guides/http_and_routing/request_and_response.cr
@@ -112,7 +112,7 @@ class Guides::HttpAndRouting::RequestAndResponse < GuideAction
     end
     ```
 
-    You can read more about working with headers in the [Crystal docs on HTTP::Headers](https://crystal-lang.org/api/0.30.1/HTTP/Headers.html).
+    You can read more about working with headers in the [Crystal docs on HTTP::Headers](https://crystal-lang.org/api/HTTP/Headers.html).
 
     #{permalink(ANCHOR_HANDLING_RESPONSES)}
     ## Handling Responses


### PR DESCRIPTION
Hi,  here is a local PR for try to fix some document issue when i am reading lucky document, some of them fixed by #1185, please have a look.

Following is some explain:

1.  i never saw a method named `render_flash`?

3.    `` The `path` method takes an `anchor` argument.``, where is the path method?