### PR TITLE
Fix incorrect AuthLayout example in i18n guide

### DIFF
--- a/src/actions/guides/frontend/internationalization.cr
+++ b/src/actions/guides/frontend/internationalization.cr
@@ -356,7 +356,7 @@ class Guides::Frontend::Internationalization < GuideAction
     abstract class AuthLayout
       # ...
       def page_title
-        r(".page_name").t
+        r(".page_title").t
       end
 
       def render


### PR DESCRIPTION
This fixes a compilation error caused by an incorrect key encountered while following the internationalization guide.