### PR TITLE
Rename Log to LogEntry in Logs::Index example

### DIFF
--- a/src/actions/guides/http_and_routing/request_and_response.cr
+++ b/src/actions/guides/http_and_routing/request_and_response.cr
@@ -325,10 +325,10 @@ class Guides::HttpAndRouting::RequestAndResponse < GuideAction
     respectively.
 
     ```crystal
-    class Logs::Index < BrowserAction
-      get "/logs" do
-        logs = LogQuery.new
-        html IndexPage, logs: logs
+    class LogEntries::Index < BrowserAction
+      get "/log_entries" do
+        log_entries = LogEntryQuery.new
+        html IndexPage, log_entries: log_entries
       end
 
       def html_content_type


### PR DESCRIPTION
Because `Log` is used by Crystal std lib (https://crystal-lang.org/api/1.11.2/Log.html) you can't declare an Avram model like :

```crystal
class Log < BaseModel
  table do
    # You will define columns here. For example:
    # column name : String
  end
end
```

You'll get a compile time error.

One of the example of the website uses `LogQuery` and thus misleads you can have a model named simply `Log`.

I got bit by this in one of my project. One solution I found was to use the `LogEntry` name instead.

Open to any other name suggestions.