### PR TITLE
Remove mention of be_on_page in Flow guides

### DIFF
--- a/src/actions/guides/testing/html_and_interactivity.cr
+++ b/src/actions/guides/testing/html_and_interactivity.cr
@@ -54,9 +54,6 @@ class Guides::Testing::HtmlAndInteractivity < GuideAction
 
     ### Create a Flow spec in spec/flows/
 
-    When writing flow specs, it’s best to *write the spec as a full flow that a
-    user might take*. For example, here is a flow for publishing an article:
-
     When writing flow specs, your flow object will handle all of the interactions,
     and should read as a step-by-step guide that a user will take flowing from point A to B.
     Each of your spec assertions can remain in the spec for transparency.

--- a/src/actions/guides/testing/html_and_interactivity.cr
+++ b/src/actions/guides/testing/html_and_interactivity.cr
@@ -57,6 +57,10 @@ class Guides::Testing::HtmlAndInteractivity < GuideAction
     When writing flow specs, it’s best to *write the spec as a full flow that a
     user might take*. For example, here is a flow for publishing an article:
 
+    When writing flow specs, your flow object will handle all of the interactions,
+    and should read as a step-by-step guide that a user will take flowing from point A to B.
+    Each of your spec assertions can remain in the spec for transparency.
+
     ```crystal
     # spec/flows/publish_post_spec.cr
     describe "Publish post flow" do
@@ -65,10 +69,12 @@ class Guides::Testing::HtmlAndInteractivity < GuideAction
 
         flow.start_draft
         flow.create_draft
-        flow.draft_should_be_saved
+        flow.should have_element("@draft-title")
         flow.open_draft
         flow.publish_post
-        flow.post_should_be_published
+
+        flow.should have_element("@post-title")
+        flow.should have_text("Published Post")
       end
     end
     ```
@@ -92,10 +98,6 @@ class Guides::Testing::HtmlAndInteractivity < GuideAction
         click "@save-draft"
       end
 
-      def draft_should_be_created
-        draft_title.should be_on_page
-      end
-
       def open_draft
         draft_title.click
       end
@@ -108,10 +110,6 @@ class Guides::Testing::HtmlAndInteractivity < GuideAction
         fill_form PublishArticle,
           title: "Published Post"
         click "@publish-post"
-      end
-
-      def post_should_be_published
-        el("@post-title", text: "Published Post").should be_on_page
       end
     end
     ```
@@ -320,11 +318,12 @@ class Guides::Testing::HtmlAndInteractivity < GuideAction
 
     ### Asserting elements are on the page
 
-    You can use `el` combined with the `be_on_page` matcher to assert that an
-    element is on the page:
+    You can use the `have_element` and `have_text` expectations to check for specific elements using CSS
+    selectors, or elements containing specific text.
 
     ```crystal
-    el("@post-title", text: "My post").should be_on_page
+    flow.should have_element(%(span[data-arg="4"]))
+    flow.should have_text("Welcome")
     ```
 
     ### Asserting the current URL path


### PR DESCRIPTION
Fixes #1286
Fixes #1075

Also related: https://github.com/luckyframework/lucky_flow/issues/150

Since this method was removed, it no longer makes much sense writing your spec assertions inside of the spec file since you'd have to do stuff like `self.should have_element` which reads very weird. 