### PR TITLE
Document String primary keys.

### DIFF
--- a/src/actions/guides/database/migrations.cr
+++ b/src/actions/guides/database/migrations.cr
@@ -145,11 +145,13 @@ class Guides::Database::Migrations < GuideAction
     * `Int64` - Maps to postgres `bigint`.
     * `Time` - Maps to postgres `timestamptz`.
     * `Bool` - Maps to postgres `boolean`.
-    * `Float64` - Maps to postgres `decimal`. With options for precision and scale.
+    * `Float64` - Maps to postgres `numeric`. With options for precision and scale.
     * `UUID` - Maps to postgres `uuid`.
     * `Bytes` - Maps to postgres `bytea`.
     * `JSON::Any` - Maps to postgres `jsonb`.
     * `Array(T)` - Maps to postgres array fields where `T` is any of the other datatypes.
+
+    > Enums are also support on the Crystal side. They map to an Int that you specify for the postgres side
 
     ### Adding a column
 
@@ -314,6 +316,7 @@ class Guides::Database::Migrations < GuideAction
     * `Int32` - maps to postgres `serial`.
     * `Int64` - maps to postgres `bigserial`.
     * `UUID` - maps to postgres `uuid`. Generates V4 UUID (requires the "pgcrypto" extension)
+    * `String` - maps to postgres `text`.
 
     To specify your primary key, you'll use the `primary_key` method.
 

--- a/src/actions/guides/database/models.cr
+++ b/src/actions/guides/database/models.cr
@@ -170,7 +170,7 @@ class Guides::Database::Models < GuideAction
     ### Setting the primary key
 
     The primary key is `Int64` by default. If that's what you need, then everything is already set for
-    you. If you need `Int32`, `Int16`, `UUID`, or your own custom set one, you'll need to update the
+    you. If you need `Int32`, `Int16`, `UUID`, or your own custom `String`, you'll need to update the
     `primary_key` in your `BaseModel` or set one in the `table` macro.
 
     Setting your primary key with the `primary_key` method works the same as you did in
@@ -182,6 +182,18 @@ class Guides::Database::Models < GuideAction
       macro default_columns
         # Sets the type for `id` to `UUID`
         primary_key id : UUID
+        timestamps
+      end
+    end
+    ```
+
+    For `String` primary keys, you will need to define a method that generates the value when the record is saved.
+
+    ```crystal
+    abstract class BaseModel < Avram::Model
+      macro default_columns
+        # Sets the type for `id` to `text`
+        primary_key id : String = UUID.v7.to_s
         timestamps
       end
     end


### PR DESCRIPTION
Fixes #1294

Also fixed a typo in the migration guides.