### PR TITLE
Improvements to Postgresql documentation

### DIFF
--- a/src/actions/guides/database/database_setup.cr
+++ b/src/actions/guides/database/database_setup.cr
@@ -28,8 +28,8 @@ class Guides::Database::DatabaseSetup < GuideAction
 
     * database : `String` - This is the name of your database. The default is set at the top of this file.
     * hostname : `String?` - The host where your database is located. Generally "localhost".
-    * username : `String?` - Your database user.
-    * password : `String?` - Your password.
+    * username : `String?` - Your database user. Our example uses a database user "lucky".
+    * password : `String?` - Your password. (Caution: do not store production passwords in your src repo)
     * port : `Int32?` - The port to connect to. Default is `5432`
     * query : `String?` - A query string of connection pool settings.
 
@@ -40,7 +40,8 @@ class Guides::Database::DatabaseSetup < GuideAction
         database: database_name,
         hostname: "localhost",
         port: 5432,
-        username: "postgres",
+        username: "lucky",
+        password: "lucky",
         query: "initial_pool_size=5&retry_attempts=2"
       )
     end
@@ -88,7 +89,7 @@ class Guides::Database::DatabaseSetup < GuideAction
     (e.g. `query: "initial_pool_size=5&max_pool_size=10"`).
 
     > If using a connection string, set the query at the end.
-    > (e.g. `postgres://postgres@localhost/my_db?initial_pool_size=5`)
+    > (e.g. `postgres://lucky@localhost/my_db?initial_pool_size=5`)
 
     ### Other Avram Options
 
@@ -228,8 +229,8 @@ class Guides::Database::DatabaseSetup < GuideAction
       settings.credentials = Avram::Credentials.parse?(ENV["SECOND_DATABASE_URL"]?) || Avram::Credentials.new(
         database: "db_two",
         hostname: "localhost",
-        username: "postgres",
-        password: "postgres"
+        username: "dbuser2",
+        password: "pass2"
       )
     end
     ```

--- a/src/actions/guides/getting-started/installing.cr
+++ b/src/actions/guides/getting-started/installing.cr
@@ -237,7 +237,7 @@ class Guides::GettingStarted::Installing < GuideAction
 
     There are other installation methods available in [Postgres CLI tools docs](https://postgresapp.com/documentation/cli-tools.html)
 
-    ### 1b. (Linux only) Password-less logins for local development
+    ### 1b. (Linux only) Configure PostgreSQL authentication trust for local development
 
     Homebrew installed PostgreSQL on macOS are configured by default to allow password-less logins. But for Linux, if you wish to
     use PostgreSQL without a password, you'll need to ensure your `pg_hba.conf` file is updated.
@@ -253,12 +253,16 @@ class Guides::GettingStarted::Installing < GuideAction
     host    all             all             ::1/128                 trust
     ```
 
-    Visit [PostgreSQL Authentication Methods](https://www.postgresql.org/docs/12/auth-methods.html) to learn
+    Visit [PostgreSQL Authentication Methods](https://www.postgresql.org/docs/14/auth-methods.html) to learn
     more more about available authentication methods and how to configure them for PostgreSQL.
 
     > Restart the `postgresql` service to activate the configuration changes.
 
-    ### 2. Ensure Postgres CLI tools installed
+    ```bash
+    sudo systemctl restart postgresql
+    ```
+
+    ### 2. Verify PostgreSQL CLI client (psql) is installed
 
     First open a new session to reload your terminal, then:
 
@@ -267,6 +271,51 @@ class Guides::GettingStarted::Installing < GuideAction
     ```
 
     Should return `psql (PostgreSQL) 10.x` or higher.
+
+    ### 3. Create a database user and set a password
+
+    You will need to create a database user with proper permissions to allow Lucky to manage the application database.
+    There are several ways to accomplish this, but fortunatly PostgreSQL ships several command line tools to simplify
+    this step. You will need to become the 'postgres' user:
+    ```bash
+    sudo su - postgres
+    ```
+
+    Now create the user, and set the roles `createrole`, `superuser`, `createdb` then enter a password. In
+    this example below, we will create a user named 'lucky' and set a password of 'lucky'.
+    ```bash
+    createuser -dsrP lucky
+    ```
+
+    > Due to a bug in Lucky version 1.20, you will have to create a database with the same name as your
+    > postgres user, otherwise the setup script and database tasks will fail after init. This will be fixed in the
+    > next release
+    ```bash
+    createdb -O lucky lucky
+    ```
+
+
+    Return back to your normal user.
+    ```bash
+    exit
+    ```
+
+    Now test the user can connect to the local postgres datbabase, enter the password for the user you just created when prompted.
+    ```bash
+    psql -h localhost -U lucky -W postgres
+    ```
+
+    If successful, you should see the following output, then type `\\q` and hit `enter` to quit the client.
+    ```
+    > psql -h localhost -U lucky -W postgres
+
+    Password:
+    psql (14.12 (Ubuntu 14.12-0ubuntu0.22.04.1))
+    SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, bits: 256, compression: off)
+    Type "help" for help.
+
+    postgres=#  \ \q
+    ```
 
     #{permalink(ANCHOR_NODE)}
     ## Node and Yarn (optional)

--- a/src/actions/guides/getting-started/installing.cr
+++ b/src/actions/guides/getting-started/installing.cr
@@ -276,24 +276,23 @@ class Guides::GettingStarted::Installing < GuideAction
 
     You will need to create a database user with proper permissions to allow Lucky to manage the application database.
     There are several ways to accomplish this, but fortunatly PostgreSQL ships several command line tools to simplify
-    this step. You will need to become the 'postgres' user:
+    this step. You will need to become the "postgres" user:
     ```bash
     sudo su - postgres
     ```
 
     Now create the user, and set the roles `createrole`, `superuser`, `createdb` then enter a password. In
-    this example below, we will create a user named 'lucky' and set a password of 'lucky'.
+    this example below, we will create a user named "lucky" and set a password of "lucky".
     ```bash
     createuser -dsrP lucky
     ```
 
-    > Due to a bug in Lucky version 1.20, you will have to create a database with the same name as your
-    > postgres user, otherwise the setup script and database tasks will fail after init. This will be fixed in the
-    > next release
+    > Lucky versions 1.1.0 - 1.2.0 expects an existing database with the same name as the user you created in the
+    > previous step. The setup script and database tasks will fail after init if it does not exist. This requirement
+    > wil be removed in the next release.
     ```bash
     createdb -O lucky lucky
     ```
-
 
     Return back to your normal user.
     ```bash
@@ -314,7 +313,7 @@ class Guides::GettingStarted::Installing < GuideAction
     SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, bits: 256, compression: off)
     Type "help" for help.
 
-    postgres=#  \ \q
+    postgres=# \\q
     ```
 
     #{permalink(ANCHOR_NODE)}


### PR DESCRIPTION
I have written some additonal steps for setting up PostgreSQL on Linux. improvements include:

- workaround for Lucky 1.20 bug with database create on Linux which requires addition of a local database named the same as the user specified in the databse config
- added notes on creating a local database user with the 'createuser' command included with postgres
- modified reference of Postgresql documentation to v14
- replaced references to using the builtin 'postgres' user with a user called 'lucky', it is best practice to never use the built in sa or superuser account of a database
- minor notes and changes to improve readability.